### PR TITLE
Monach compatibility localization and visibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -518,6 +518,10 @@
             "c": " C",
             "d": " D"
 
+        },
+        "poolToggle":{
+            "inPool": "Card in pool",
+            "toogle": "Toggle pooled"
         }
 
     },

--- a/torgeternity.js
+++ b/torgeternity.js
@@ -374,17 +374,17 @@ Hooks.on("ready", async function() {
 
 Hooks.on("getMonarchHandComponents", (hand, components) => {
     components.markers.push({
-        tooltip: "Card in pool",
+        tooltip: `${game.i18n.localize("torgeternity.poolToggle.inPool")}`,
         class: "pool-marker",
-        icon: "fas fa-circle",
-        color: "#800080",
+        icon: "fas fa-tags",
+        color: "#00BFFF",
         show: (card) => card.getFlag("torgeternity", "pooled")
     });
     components.controls.push({
         class: "pool-toggle",
-        tooltip: "Toggle pooled",
-        icon: "fas fa-circle",
-        color: "#800080",
+        tooltip: `${game.i18n.localize("torgeternity.poolToggle.toogle")}`,
+        icon: "fas fa-tags",
+        color: "#00BFFF",
         onclick: (event, card) => card.setFlag("torgeternity", "pooled", !card.getFlag("torgeternity", "pooled"))
     })
 });


### PR DESCRIPTION
* Changes icon and color of Monarch pooled toggle: using the default purple circle produces confusion with default purple monarch marker (included by default by Monarch). So you can tag a card with torg-pooled (which is a purple circle) and with the default monarch purple tag (which is also a purple circle).
* Adds localization to the marker.
