### PR TITLE
rollItemMacro typo

### DIFF
--- a/torgeternity.js
+++ b/torgeternity.js
@@ -558,7 +558,7 @@ function rollItemMacro(itemName) {
     const item = actor ? actor.items.find((i) => i.name === itemName) : null;
     if (!item)
         return ui.notifications.warn(
-            game.i18n.localize('torgeternity.notifications.noItemNamed') + item.name
+            game.i18n.localize('torgeternity.notifications.noItemNamed') + itemName
         );
 
     // Trigger the item roll


### PR DESCRIPTION
If player doesn't have the item involved in the macro then "item.name" throws an error. Replaced by "itemName", argument of the macro, and name of the item