### PR TITLE
Single for Effects

### DIFF
--- a/module/sheets/torgeternityActorSheet.js
+++ b/module/sheets/torgeternityActorSheet.js
@@ -387,18 +387,17 @@ export default class torgeternityActorSheet extends ActorSheet {
 
     //compute adds from total for threats
     if (this.actor.type == "threat") {
-      html.find(".threat-skill-total").change(this.setThreatAdds.bind(this));
+      html.find(".skill-element-edit .inputsFav").change(this.setThreatAdds.bind(this));
     }
   }
   async setThreatAdds(event) {
-    let data = this.actor.data;
-
-    let skill = event.currentTarget.dataset.skill;
+    let data = this.actor.system;
+    let skill = event.target.dataset.skill;
     let skillObject = this.actor.system.skills[skill];
-
-    system.skills[skill].adds = event.currentTarget.value - this.actor.system.attributes[skillObject.baseAttribute];
-    this.actor.update(data);
+    var computedAdds = event.target.value - this.actor.system.attributes[skillObject.baseAttribute];
+    await this.actor.update({ [`system.skills.${skill}.adds`]: computedAdds });
   }
+
   async onOpenHand(event) {
     let characterHand = this.object.getDefaultHand();
     // if default hand => render it

--- a/module/torgeternityActor.js
+++ b/module/torgeternityActor.js
@@ -177,8 +177,10 @@ export default class torgeternityActor extends Actor {
     // Derive Skill values for Storm Knights
     //
     // NOTE: Threat skill values are created directly by user, but SK skill values are derived based on attribute + adds.
-    //
-    if (this._source.type === "stormknight") {
+    // NOTE bis, with setThreatAdds() doing his job, skill.value can be used for both,
+    // with possibility to use same path for effects => system.skills.xxx.adds
+
+    if ((this._source.type === "stormknight") | (this._source.type === "threat")) {
       for (let [name, skill] of Object.entries(skillset)) {
         if (this._source.system.skills[name].adds === null) {
           if (skill.unskilledUse === 1) {

--- a/templates/actors/threat/stat-tab.hbs
+++ b/templates/actors/threat/stat-tab.hbs
@@ -375,7 +375,7 @@
 					<span style="position:relative">{{localize (concatSkillName key)}}
 					</span>
 					<span class="inputsFav">
-						<input name="system.skills.{{key}}.value" type="number" class="small-input"
+						<input name="system.skills.{{key}}.value" data-skill="{{key}}" type="number" class="small-input"
 							value="{{skill.value}}" data-dtype="Number" />
 
 						<a class="toggleFav {{#if skill.isFav}}checked


### PR DESCRIPTION
At this moment, the system.skills.(skill).adds works only for SK With the setThreatAdds fix, when modifying a skill value in threatSheet it computes the associated adds, and skills values can be evaluated as for SK. It allows the use of the same attribute key for effects.

closes 335