### PR TITLE
Fix DSN integration & Card Setting Dialog on Forge

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # TORG Eternity Changelog
 
-## v13.0.2
+## v13.0.4
+
+- No errors when used with Dice So Nice!
+- Card Editor Dialog should use the correct template on Forge.
+
+## v13.0.3
 
 - **Dragging** items and skills to the Hotbar should now create the relevant macro.
 - Configure key now closes PossibilityByCosm if it is already open.

--- a/module/cards/cardSettingMenu.js
+++ b/module/cards/cardSettingMenu.js
@@ -26,7 +26,7 @@ export default class DeckSettingMenu extends HandlebarsApplicationMixin(Applicat
   }
 
   static PARTS = {
-    form: { template: '/systems/torgeternity/templates/cards/settingMenu.hbs', scrollable: [""] },
+    form: { template: 'systems/torgeternity/templates/cards/settingMenu.hbs', scrollable: [""] },
     footer: { template: "templates/generic/form-footer.hbs" },
   }
 

--- a/module/preloadTemplates.js
+++ b/module/preloadTemplates.js
@@ -100,7 +100,14 @@ export const preloadTemplates = async function () {
     `systems/torgeternity/templates/items/vehicleAddOn-sheet.hbs`,
 
     // Cards
+    "systems/torgeternity/templates/cards/torgeternityCard.hbs",
+    "systems/torgeternity/templates/cards/torgeternityPlayerHand.hbs",
     "systems/torgeternity/templates/cards/torgeternityPlayerHand_lifelike.hbs",
+    "systems/torgeternity/templates/cards/settingMenu.hbs",
+    "systems/torgeternity/templates/cards/torgeternityDeck-details.hbs",
+    "systems/torgeternity/templates/cards/torgeternityDeck-cards.hbs",
+    "systems/torgeternity/templates/cards/torgeternityPile.hbs",
+
   ];
 
   // Load the template parts

--- a/module/torgchecks.js
+++ b/module/torgchecks.js
@@ -895,8 +895,17 @@ export async function renderSkillChat(test) {
 
     // roll Dice once, and handle the error if DSN is not installed
     if (game.dice3d) {
-      if (i === 0) await game.dice3d.showForRoll(test.diceroll, game.user, true);
-      game.dice3d.showForRoll(iteratedRoll);
+      // catch errors to prevent DSN from overly affecting our own behaviour.
+      if (first && test.diceroll) {
+        try {
+          await game.dice3d.showForRoll(test.diceroll, game.user, true);
+        } catch (e) { console.log('TORG CHECK: DSN reported', e) }
+      }
+      if (iteratedRoll) {
+        try {
+          await game.dice3d.showForRoll(iteratedRoll);
+        } catch (e) { console.log('TORG CHECK: DSN reported', e) }
+      }
     }
     iteratedRoll = undefined;
 


### PR DESCRIPTION
- No errors when used with Dice So Nice!
- Card Editor Dialog should use the correct template on Forge.