### PR TITLE
Bug fixes: Especially getting the Poss/Up/Hero/Drama buttons working

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # TORG Eternity Changelog
 
-## 13.2.2
+## v13.2.2
 
 - Prevent crash of Combat Tracker when actor for a combatant has been deleted.
 - Chat messages for Drama conditions show proper text instead of `{faction}`.
@@ -9,7 +9,7 @@
 - Ensure that the Possibility/Up/Hero/Drama/+3 buttons add to the bonus properly.
 - Prevent error from BD button when chat card has no target.
 
-## 13.2.1
+## v13.2.1
 
 - Fix an issue with the Combat Tracker generating errors with unsupported cards.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Prevent crash of Combat Tracker when actor for a combatant has been deleted.
 - Chat messages for Drama conditions show proper text instead of `{faction}`.
 - Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
+- Extra protection to prevent errors if card decks don't exist.
 
 ## 13.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
 - Extra protection to prevent errors if card decks don't exist.
 - Ensure that the Possibility/Up/Hero/Drama/+3 buttons add to the bonus properly.
+- Prevent error from BD button when chat card has no target.
 
 ## 13.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ## 13.2.2
 
 - Prevent crash of Combat Tracker when actor for a combatant has been deleted.
+- Chat messages for Drama conditions show proper text instead of `{faction}`.
+- Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
 
 ## 13.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,11 +2,11 @@
 
 ## v13.2.2
 
+- Ensure that the **Possibility/Up/Hero/Drama/+3** buttons add to the bonus properly.
 - Prevent crash of Combat Tracker when actor for a combatant has been deleted.
 - Chat messages for Drama conditions show proper text instead of `{faction}`.
 - Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
 - Extra protection to prevent errors if card decks don't exist.
-- Ensure that the Possibility/Up/Hero/Drama/+3 buttons add to the bonus properly.
 - Prevent error from BD button when chat card has no target.
 
 ## v13.2.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # TORG Eternity Changelog
 
+## 13.2.2
+
+- Prevent crash of Combat Tracker when actor for a combatant has been deleted.
+
 ## 13.2.1
 
 - Fix an issue with the Combat Tracker generating errors with unsupported cards.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Chat messages for Drama conditions show proper text instead of `{faction}`.
 - Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
 - Extra protection to prevent errors if card decks don't exist.
+- Ensure that the Possibility/Up/Hero/Drama/+3 buttons add to the bonus properly.
 
 ## 13.2.1
 

--- a/module/canvas/tokenruler.js
+++ b/module/canvas/tokenruler.js
@@ -4,7 +4,7 @@ export default class TorgEternityTokenRuler extends foundry.canvas.placeables.to
 
   _getWaypointLabelContext(waypoint, state) {
     const context = super._getWaypointLabelContext(waypoint, state);
-    if (!context || !context.cost.total || this.token.actor.type === 'vehicle') return context;
+    if (!context || !context.cost.total || !this.token.actor || this.token.actor.type === 'vehicle') return context;
     const cost = context.cost.total;
     const move = this.token?.actor.system.other.move;
     const walking = this.token.document.movementAction === 'walk';

--- a/module/cards/setUpCardPiles.js
+++ b/module/cards/setUpCardPiles.js
@@ -90,6 +90,6 @@ export async function setUpCardPiles() {
       await sk.createDefaultHand();
     }
   }
-  game.settings.set('torgeternity', 'deckSetting', deckSetting);
-  game.settings.set('torgeternity', 'setUpCards', false);
+  await game.settings.set('torgeternity', 'deckSetting', deckSetting);
+  await game.settings.set('torgeternity', 'setUpCards', false);
 }

--- a/module/cards/setUpCardPiles.js
+++ b/module/cards/setUpCardPiles.js
@@ -68,7 +68,7 @@ export async function setUpCardPiles() {
   }
 
   // Add Active Drama
-  if (!game.cards.get(deckSetting.activeDrama)) {
+  if (!game.cards.get(deckSetting.dramaActive)) {
     const cardData = {
       name: game.i18n.localize('torgeternity.cardTypes.activeDrama'),
       type: 'pile',

--- a/module/cards/torgeternityPlayerHand.js
+++ b/module/cards/torgeternityPlayerHand.js
@@ -182,34 +182,32 @@ export default class torgeternityPlayerHand extends foundry.applications.sheets.
         {
           await card.unsetFlag('torgeternity', 'pooled');
           const settings = game.settings.get('torgeternity', 'deckSetting');
-          const pile = (card.type === 'destiny') ? settings.destinyDiscard : settings.cosmDiscard;
-          await card.pass(game.cards.get(pile), game.torgeternity.cardChatOptions);
+          const discardPile = game.cards.get((card.type === 'destiny') ? settings.destinyDiscard : settings.cosmDiscard);
+          if (!discardPile) return;
+          await card.pass(discardPile, game.torgeternity.cardChatOptions);
           card.toMessage({
-            content: `<div class="card-draw flexrow"><span class="card-chat-tooltip"><img class="card-face" src="${card.img
-              }"/><span><img src="${card.img
-              }"></span></span><span class="card-name">${game.i18n.localize(
-                'torgeternity.chatText.discardsCard'
-              )} ${card.name}</span>
-              </div>`,
+            content: `<div class="card-draw flexrow"><span class="card-chat-tooltip">
+            <img class="card-face" src="${card.img}"/><span><img src="${card.img}"></span></span>
+            <span class="card-name">${game.i18n.localize('torgeternity.chatText.discardsCard')} ${card.name}</span>
+            </div>`,
           });
           return;
         }
       case 'play':
-        await card.unsetFlag('torgeternity', 'pooled');
-        if (card.type == 'destiny') {
-          await card.pass(game.cards.get(game.settings.get('torgeternity', 'deckSetting').destinyDiscard), game.torgeternity.cardChatOptions);
-        } else {
-          await card.pass(game.cards.get(game.settings.get('torgeternity', 'deckSetting').cosmDiscard, game.torgeternity.cardChatOptions));
-        }
-        card.toMessage({
-          content: `<div class="card-draw flexrow"><span class="card-chat-tooltip"><img class="card-face" src="${card.img
-            }"/><span><img src="${card.img
-            }"></span></span><span class="card-name">${game.i18n.localize(
-              'torgeternity.chatText.playsCard'
-            )} ${card.name}</span>
+        {
+          await card.unsetFlag('torgeternity', 'pooled');
+          const settings = game.settings.get('torgeternity', 'deckSetting');
+          const discardPile = game.cards.get((card.type === 'destiny') ? settings.destinyDiscard : settings.cosmDiscard);
+          if (!discardPile) return;
+          await card.pass(discardPile, game.torgeternity.cardChatOptions);
+          card.toMessage({
+            content: `<div class="card-draw flexrow"><span class="card-chat-tooltip">
+            <img class="card-face" src="${card.img}"/><span><img src="${card.img}"></span></span>
+            <span class="card-name">${game.i18n.localize('torgeternity.chatText.playsCard')} ${card.name}</span>
             </div>`,
-        });
-        return;
+          });
+          return;
+        }
     }
   }
 
@@ -218,18 +216,15 @@ export default class torgeternityPlayerHand extends foundry.applications.sheets.
   }
 
   static #onDrawDestiny() {
-    const destinyDeck = game.cards.get(
-      game.settings.get('torgeternity', 'deckSetting').destinyDeck
-    );
+    const destinyDeck = game.cards.get(game.settings.get('torgeternity', 'deckSetting').destinyDeck);
+    if (!destinyDeck) return;
     if (destinyDeck.cards.size) {
       const [firstCardKey] = destinyDeck.cards.keys(); // need to grab a card to get toMessage access
       const card = destinyDeck.cards.get(firstCardKey);
       card.toMessage({
-        content: `<div class="card-draw flexrow"><span class="card-chat-tooltip"><img class="card-face" src="${destinyDeck.img
-          }"/><span><img src="${destinyDeck.img
-          }"></span></span><h4 class="card-name">${game.i18n.localize(
-            'torgeternity.chatText.drawsCard'
-          )} ${destinyDeck.name}.</h4></div>`,
+        content: `<div class="card-draw flexrow"><span class="card-chat-tooltip">
+        <img class="card-face" src="${destinyDeck.img}"/><span><img src="${destinyDeck.img}"></span></span>
+        <h4 class="card-name">${game.i18n.localize('torgeternity.chatText.drawsCard')} ${destinyDeck.name}.</h4></div>`
       });
     }
     return this.document.draw(destinyDeck, 1, { face: 1, ...game.torgeternity.cardChatOptions });

--- a/module/dramaticScene/torgeternityCombat.js
+++ b/module/dramaticScene/torgeternityCombat.js
@@ -23,7 +23,7 @@ export default class TorgCombat extends Combat {
     if (!super._preDelete(options, user)) return false;
 
     // listing of hands' actors in closing combat
-    this.combatants.filter(combatant => combatant.actor.type === 'stormknight')
+    this.combatants.filter(combatant => combatant.actor?.type === 'stormknight')
       .forEach(combatant => {
         const hand = game.actors.get(combatant.actorId).getDefaultHand();
         // delete the flag that give the pooled condition in each card of each hand
@@ -235,7 +235,7 @@ export default class TorgCombat extends Combat {
    */
   async #deleteActiveDefense() {
     for (const combatant of this.combatants) {
-      const activeDefenseEffect = combatant.actor.appliedEffects.find((eff) => eff.name === 'ActiveDefense');
+      const activeDefenseEffect = combatant.actor?.appliedEffects.find((eff) => eff.name === 'ActiveDefense');
       if (activeDefenseEffect) await activeDefenseEffect.delete();
     }
   }
@@ -249,7 +249,7 @@ export default class TorgCombat extends Combat {
   }
   getFactionActors(faction) {
     const disposition = (faction === 'heroes') ? CONST.TOKEN_DISPOSITIONS.FRIENDLY : CONST.TOKEN_DISPOSITIONS.HOSTILE;
-    return this.turns.filter(combatant => combatant.token.disposition === disposition).map(combatant => combatant.actor);
+    return this.turns.filter(combatant => combatant.token?.disposition === disposition && combatant.actor).map(combatant => combatant.actor);
   }
   setCardsPlayable(value) {
     for (const actor of this.getFactionActors('heroes')) {
@@ -343,13 +343,14 @@ export default class TorgCombat extends Combat {
   dramaEndOfTurn(combatant) {
     if (this.getFlag('torgeternity', FATIGUED_FACTION_FLAG) === this.getCombatantFaction(combatant)) {
       const actor = combatant.actor;
+      if (!actor) return;
 
       let chatOutput = `<h2>${game.i18n.localize(
         'torgeternity.sheetLabels.fatigue'
       )}!</h2><p>${game.i18n.localize('torgeternity.macros.fatigueMacroDealtDamage')}</p><ul>`;
 
       if (actor.hasStatusEffect('unconscious')) {
-        chatOutput += `<li>${combatant.actor.name} ${game.i18n.localize('torgeternity.macros.fatigueMacroCharAlreadyKO')}</li>`;
+        chatOutput += `<li>${actor.name} ${game.i18n.localize('torgeternity.macros.fatigueMacroCharAlreadyKO')}</li>`;
       }
 
       const shockIncrease = actor.fatigue;

--- a/module/dramaticScene/torgeternityCombat.js
+++ b/module/dramaticScene/torgeternityCombat.js
@@ -46,7 +46,7 @@ export default class TorgCombat extends Combat {
       const dramaDiscard = game.cards.get(settings.dramaDiscard);
       const dramaActive = game.cards.get(settings.dramaActive);
       // Discard the current Drama Card
-      if (dramaActive.cards.size > 0) {
+      if (dramaDiscard && dramaActive?.cards.size > 0) {
         dramaActive.cards.contents[0].pass(dramaDiscard, game.torgeternity.cardChatOptions);
       }
     }
@@ -111,6 +111,7 @@ export default class TorgCombat extends Combat {
    */
   async resetDramaDeck() {
     const dramaDeck = game.cards.get(game.settings.get('torgeternity', 'deckSetting').dramaDeck);
+    if (!dramaDeck) return;
     await dramaDeck.recall();
     await dramaDeck.shuffle();
     // Mark no active drama card
@@ -129,10 +130,10 @@ export default class TorgCombat extends Combat {
     const dramaActive = game.cards.get(settings.dramaActive);
 
     // Discard the current Drama Card
-    if (dramaActive.cards.size > 0)
+    if (dramaDiscard && dramaActive?.cards.size > 0)
       await dramaActive.cards.contents[0].pass(dramaDiscard, game.torgeternity.cardChatOptions);
 
-    if (!dramaDeck.availableCards.length) {
+    if (!dramaDeck?.availableCards.length) {
       ui.notifications.info(game.i18n.localize('torgeternity.notifications.dramaDeckEmpty'));
       return;
     }
@@ -374,6 +375,8 @@ export default class TorgCombat extends Combat {
     const dramaDeck = game.cards.get(settings.dramaDeck);
     const dramaDiscard = game.cards.get(settings.dramaDiscard);
     const dramaActive = game.cards.get(settings.dramaActive);
+    if (!dramaDeck || !dramaDiscard || !dramaActive) return;
+
     const currActiveCard = Array.from(dramaActive.cards).pop();
     const prevActiveCard = Array.from(dramaDiscard.cards).pop();
     // Ignore game.torgeternity.cardChatOptions, since no explicit chat message sent here

--- a/module/dramaticScene/torgeternityCombat.js
+++ b/module/dramaticScene/torgeternityCombat.js
@@ -258,22 +258,23 @@ export default class TorgCombat extends Combat {
     }
   }
 
-  #sendDramaChat(action) {
+  #sendDramaChat(action, faction) {
     ChatMessage.create({
       speaker: ChatMessage.getSpeaker({ alias: game.user.name }),
-      content: game.i18n.localize(`torgeternity.drama.${action}Desc`)
+      content: game.i18n.format(`torgeternity.drama.${action}Desc`,
+        { faction: game.i18n.localize(`torgeternity.combat.${faction}`) })
     });
   }
 
   async dramaFlurry(faction) {
     // extra turn
     console.log('Drama Flurry', faction)
-    this.#sendDramaChat('flurry');
+    this.#sendDramaChat('flurry', faction);
   }
 
   async dramaInspiration(faction) {
     console.log('Drama Inspiration', faction)
-    this.#sendDramaChat('inspiration');
+    this.#sendDramaChat('inspiration', faction);
 
     // immediately recover 2 shock (see macros.js:reviveShock)
     let chatOutput = `<h2>${game.i18n.localize(
@@ -298,41 +299,41 @@ export default class TorgCombat extends Combat {
   async dramaUp(faction) {
     // UP on first roll for each actor
     console.log('Drama Up', faction)
-    this.#sendDramaChat('up');
+    this.#sendDramaChat('up', faction);
   }
 
   async dramaConfused(faction) {
     // unable to play Cards from their pool
     console.log('Drama Confused', faction)
     this.setCardsPlayable(false);
-    this.#sendDramaChat('confused');
+    this.#sendDramaChat('confused', faction);
   }
 
   async dramaFatigued(faction) {
     // At the end of an Actor's turn, they take 2 points of shock
     console.log('Drama Fatigued', faction)
     this.setFlag('torgeternity', FATIGUED_FACTION_FLAG, faction);
-    this.#sendDramaChat('fatigued');
+    this.#sendDramaChat('fatigued', faction);
   }
 
   async dramaSetback(faction) {
     // GM decides a likely setback
     console.log('Drama Setback', faction)
-    this.#sendDramaChat('setback');
+    this.#sendDramaChat('setback', faction);
   }
 
   async dramaStymied(faction) {
     // All Actors become Stymied until the end of their next turn
     console.log('Drama Stymied', faction)
-    this.#sendDramaChat(msg);
+    this.#sendDramaChat('surge');
     for (const actor of this.getFactionActors(faction))
-      actor.applyStymiedState('stymied');
+      actor.applyStymiedState('stymied', faction);
   }
 
   async dramaSurge(faction) {
     // All Actors must check for Contradictions
     console.log('Drama Surge', faction)
-    this.#sendDramaChat('surge');
+    this.#sendDramaChat('surge', faction);
   }
 
   /**

--- a/module/dramaticScene/torgeternityCombatTracker.js
+++ b/module/dramaticScene/torgeternityCombatTracker.js
@@ -62,7 +62,8 @@ export default class torgeternityCombatTracker extends foundry.applications.side
   async _prepareTurnContext(combat, combatant, index) {
     const context = await super._prepareTurnContext(combat, combatant, index);
 
-    const hand = combatant.actor.getDefaultHand();
+    // If actor has been deleted, then combatant.actor will be null
+    const hand = combatant.actor?.getDefaultHand();
     context.noHand = !hand;
     if (hand) {
       context.cardpool = hand.cards
@@ -70,7 +71,7 @@ export default class torgeternityCombatTracker extends foundry.applications.side
         .map(card => { return { name: card.name, img: card.img } }) ?? [];
     }
     context.turnTaken = combatant.turnTaken;
-    context.actorType = combatant.actor.type;
+    context.actorType = combatant.actor?.type;
     const dispositions = {
       [CONST.TOKEN_DISPOSITIONS.SECRET]: "secret",
       [CONST.TOKEN_DISPOSITIONS.HOSTILE]: "hostile",

--- a/module/macros.js
+++ b/module/macros.js
@@ -309,6 +309,7 @@ export class TorgeternityMacros {
     const dramaDeck = game.cards.get(setting.dramaDeck);
     // Find ?? the index of the Active Drama Card in the Drama Deck
     const activeDeck = game.cards.get(setting.dramaActive);
+    if (!dramaDeck || !activeDeck) return;
     const cardSort = (activeDeck.cards.size === 0) ? dramaDeck.size :
       dramaDeck.cards.get(activeDeck._source.cards[0]._id).sort + 1;
 
@@ -513,7 +514,7 @@ export class TorgeternityMacros {
       if (target) {
         const userid = target.id;
         const destinyDiscard = game.cards.get(game.settings.get('torgeternity', 'deckSetting').destinyDiscard);
-        const lastCard = destinyDiscard.cards.contents.pop();
+        const lastCard = destinyDiscard?.cards.contents.pop();
         if (!lastCard) return;
         const parentHand = target.character.getDefaultHand();
         const found = game.messages.contents.filter(m => m.author.id === userid);

--- a/module/macros.js
+++ b/module/macros.js
@@ -355,7 +355,7 @@ export class TorgeternityMacros {
   }
 
   async dramaFlashback() {
-    ui.combat.viewed.restorePreviousDrama();
+    game.combats.active?.restorePreviousDrama();
   }
 
   // #endregion

--- a/module/test-dialog.js
+++ b/module/test-dialog.js
@@ -226,6 +226,7 @@ export class TestDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     const fields = formData.object;
     foundry.utils.mergeObject(this.test, fields, { inplace: true });
 
+    this.test.explicitBonus = fields.bonus !== null;
     this.test.isOther1 = fields.other1Modifier != 0;
     this.test.isOther2 = fields.other2Modifier != 0;
     this.test.isOther3 = fields.other3Modifier != 0;

--- a/module/torgchecks.js
+++ b/module/torgchecks.js
@@ -59,8 +59,6 @@ export async function renderSkillChat(test) {
     test.ammoLabel = 'hidden';
   }
 
-  const newRoll = (test.bonus === null);
-
   const uniqueDN = game.settings.get('torgeternity', 'uniqueDN') ? await highestDN(test) : undefined;
   let first = true;
   for (const target of test.targetAll) {
@@ -95,7 +93,7 @@ export async function renderSkillChat(test) {
     test.unskilledLabel = test.unskilledTest ? '' : 'hidden';
 
     // Generate roll, if needed
-    if (test.rollTotal === 0 && newRoll) {
+    if (test.rollTotal === 0 && !test.explicitBonus) {
       // Generate dice roll
       const dice = test.unskilledTest ? '1d20x10' : '1d20x10x20';
 
@@ -136,7 +134,7 @@ export async function renderSkillChat(test) {
     test.dramaTotal ??= 0;
 
     // Calculate combinedRollTotal
-    if (newRoll) {
+    if (!test.explicitBonus) {
       test.combinedRollTotal = test.rollTotal + test.upTotal + test.possibilityTotal + test.heroTotal + test.dramaTotal;
       test.bonus = torgBonus(test.combinedRollTotal);
     } else {
@@ -430,7 +428,7 @@ export async function renderSkillChat(test) {
         adjustedDamage = test.damage + test.vitalAreaDamageModifier;
       }
       // add additional Damage from roll dialogue
-      if (test?.additionalDamage && newRoll) {
+      if (test?.additionalDamage && !test.explicitBonus) {
         adjustedDamage += test?.additionalDamage;
       }
       // Check for whether a target is present and turn on display of damage sub-label
@@ -456,7 +454,7 @@ export async function renderSkillChat(test) {
 
         } else {
           // Add BDs in promise if applicable as this should only be rolled if the test is successful
-          if (test.addBDs && newRoll) {
+          if (test.addBDs && !test.explicitBonus) {
             iteratedRoll = await rollBonusDie(test.trademark, test.addBDs);
             test.BDDamageInPromise = iteratedRoll.total;
             test.diceList = test.diceList.concat(iteratedRoll.dice[0].values);

--- a/module/torgchecks.js
+++ b/module/torgchecks.js
@@ -821,6 +821,7 @@ function individualDN(test, target) {
       // Find the fastest participant in the active combat
       let highestSpeed = 0;
       for (const combatant of game.combats.active.turns) {
+        if (!combatant.actor) continue;
         const combatantSpeed = (combatant.actor.type === 'vehicle') ?
           combatant.actor.system.topSpeed.value :
           getTorgValue(combatant.actor.system.other.run);

--- a/module/torgeternityChatLog.js
+++ b/module/torgeternityChatLog.js
@@ -278,7 +278,8 @@ export default class TorgeternityChatLog extends foundry.applications.sidebar.ta
     if (!chatMessage.isAuthor && !game.user.isGM) {
       return;
     }
-    test.targetAll = [test.target];
+    // Pick the specific target from the chat card to receive the BD
+    if (test.target) test.targetAll = [test.target];
     test.possibilityStyle = 'hidden';
     test.upStyle = 'hidden';
     test.dramaStyle = 'hidden';


### PR DESCRIPTION
## v13.2.2

- Ensure that the **Possibility/Up/Hero/Drama/+3** buttons add to the bonus properly.
- Prevent crash of Combat Tracker when actor for a combatant has been deleted.
- Chat messages for Drama conditions show proper text instead of `{faction}`.
- Don't create a new 'Active Drama Card' deck every time that 'Setup the Cards Directory' is used.
- Extra protection to prevent errors if card decks don't exist.
- Prevent error from BD button when chat card has no target.