### PR TITLE
13.4.0: Automated of Shields + Improved inline Condition

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 - If an explicit image is set during initial Threat creation, then use that image for the token instead of the default.
 - Reinstate hiding tabs on Threat sheet when its height goes below 630px.
 - Open Player Hand/Distance Hover now affect selected tokens for GMs (still controlled Actor for players).
+- Set hover distance label text color to White, regardless of Foundry's interface light/dark setting.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,9 @@
 - Apply an equipped **Shield's Minimum Strength**.
 - Ensure the current selections are visible when the Test Dialog is first opened.
 - If an explicit image is set during initial Threat creation, then use that image for the token instead of the default.
+- Reinstate hiding tabs on Threat sheet when its height goes below 630px.
+
+Fixes #359, #381,
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,8 @@
 - Ensure all Item sheets have the correct height.
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 - Vehicle sheet defaults to smaller height.
-- Restore styling of macro bar from V12.x
+- Restore styling of **macro bar** from V12.x
+- **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 - Vehicle sheet defaults to smaller height.
 - Restore styling of **macro bar** from V12.x
-- #359: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
+- #381: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 - Apply an equipped **Shield's Minimum Strength**.
 - Ensure the current selections are visible when the Test Dialog is first opened.
 - If a specific image is set during initial Threat creation, then use that image for the token instead of the default.
@@ -29,9 +29,10 @@
 - **Sort Combatants alphabetically** within their allegiance group.
 - **Item Sheets** now automatically size themselves.
 - **Distance to Token** label placed ABOVE the top resource bar.
-- Add a game system setting to disable core Foundry's Token Movement History feature.
+- Add a game system setting to disable core Foundry's **Token Movement History** feature.
 
-Fixes #359, #381,
+Fixes #359, #381, #544
+Previously Fixed #195, #326
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@
 - **GM Screen** pops out of the window once again.
 - Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
 - **Sort Combatants alphabetically** within their allegiance group.
+- Item Sheets now automatically size themselves.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # TORG Eternity Changelog
 
+## Next Release
+
+- Ensure all Item sheets have the correct height.
+
 ## v13.3.1
 
 - Items can be created once again.

--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@
 - **Sort Combatants alphabetically** within their allegiance group.
 - **Item Sheets** now automatically size themselves.
 - **Distance to Token** label placed ABOVE the top resource bar.
+- Add a game system setting to disable core Foundry's Token Movement History feature.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 - Ensure all Item sheets have the correct height.
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
+- Vehicle sheet defaults to smaller height.
+- Restore styling of macro bar from V12.x
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 - Set hover distance label text color to White, regardless of Foundry's interface light/dark setting.
 - **GM Screen** pops out of the window once again.
 - Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
+- **Sort Combatants alphabetically** within their allegiance group.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - #359: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 - Apply an equipped **Shield's Minimum Strength**.
 - Ensure the current selections are visible when the Test Dialog is first opened.
+- If an explicit image is set during initial Threat creation, then use that image for the token instead of the default.
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # TORG Eternity Changelog
 
-## Next Release
+## v13.4.0
 
 ### IMPORTANT
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Restore styling of **macro bar** from V12.x
 - #359: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 - Apply an equipped **Shield's Minimum Strength**.
+- Ensure the current selections are visible when the Test Dialog is first opened.
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,6 @@
 
 ### Improvements
 
-- Ensure all Item sheets have the correct height.
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 - Vehicle sheet defaults to smaller height.
 - Restore styling of **macro bar** from V12.x
@@ -28,7 +27,7 @@
 - **GM Screen** pops out of the window once again.
 - Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
 - **Sort Combatants alphabetically** within their allegiance group.
-- Item Sheets now automatically size themselves.
+- **Item Sheets** now automatically size themselves.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,11 +14,11 @@
 
 ### Improvements
 
-- Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
-- Vehicle sheet defaults to smaller height.
-- Restore styling of **macro bar** from V12.x
 - #381: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 - Apply an equipped **Shield's Minimum Strength**.
+- Change vehicle sheet to show **combined dollars+magnitude** field, to match the price field of Items.
+- Vehicle sheet defaults to smaller height.
+- Restore styling of **macro bar** from V12.x
 - Ensure the current selections are visible when the Test Dialog is first opened.
 - If a specific image is set during initial Threat creation, then use that image for the token instead of the default.
 - Reinstate hiding tabs on Threat sheet when its height goes below 630px.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@
 ### IMPORTANT
 
 - Remove Active Effects from Shields that modify the defense (dodge/melee weapons), since that is now automated.
+- `@Condition[...]` has been simplified to have just three optional words
+  - `@Condition[status]` adds the condition
+  - `@Condition[status|off]` removes the condition
+  - `@Condition[status|toggle]` toggle the on/off state of the condition
+  - `@Condition[status|overlay]` adds the condition and displays it as an overlay
+  - `@Condition[status|toggle|overlay]` toggle the on/off state of the condition, and if toggled to the on state then it will be an overlay
 
 ### Improvements
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,10 +21,11 @@
 - #359: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
 - Apply an equipped **Shield's Minimum Strength**.
 - Ensure the current selections are visible when the Test Dialog is first opened.
-- If an explicit image is set during initial Threat creation, then use that image for the token instead of the default.
+- If a specific image is set during initial Threat creation, then use that image for the token instead of the default.
 - Reinstate hiding tabs on Threat sheet when its height goes below 630px.
-- Open Player Hand/Distance Hover now affect selected tokens for GMs (still controlled Actor for players).
+- **Open Player Hand/Distance Hover** now affect selected tokens for GMs (still controlled Actor's token for players).
 - Set hover distance label text color to White, regardless of Foundry's interface light/dark setting.
+- **GM Screen** pops out of the window once again.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,8 @@
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 - Vehicle sheet defaults to smaller height.
 - Restore styling of **macro bar** from V12.x
-- **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
+- #359: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
+- Apply an equipped **Shield's Minimum Strength**.
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Ensure all Item sheets have the correct height.
+- Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 
 ## v13.3.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 ## Next Release
 
+### IMPORTANT
+
+- Remove Active Effects from Shields that modify the defense (dodge/melee weapons), since that is now automated.
+
+### Improvements
+
 - Ensure all Item sheets have the correct height.
 - Change vehicle sheet to show combined dollars+magnitude field, to match the price field of Items.
 - Vehicle sheet defaults to smaller height.

--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@
 - Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
 - **Sort Combatants alphabetically** within their allegiance group.
 - **Item Sheets** now automatically size themselves.
+- **Distance to Token** label placed ABOVE the top resource bar.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 - **Open Player Hand/Distance Hover** now affect selected tokens for GMs (still controlled Actor's token for players).
 - Set hover distance label text color to White, regardless of Foundry's interface light/dark setting.
 - **GM Screen** pops out of the window once again.
+- Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
 
 Fixes #359, #381,
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - Ensure the current selections are visible when the Test Dialog is first opened.
 - If an explicit image is set during initial Threat creation, then use that image for the token instead of the default.
 - Reinstate hiding tabs on Threat sheet when its height goes below 630px.
+- Open Player Hand/Distance Hover now affect selected tokens for GMs (still controlled Actor for players).
 
 Fixes #359, #381,
 

--- a/TODO.md
+++ b/TODO.md
@@ -19,5 +19,3 @@
 - Should the Combat Tracker support more than one combat?
 - Check all styles for Journals (esp. with the published journals).
 - 'non-lethal' trait will KO an SK, but not require a Defeat test.
-- Need to store UUID of each gunner in the Heavy Weapon Item record embedded on the vehicle.
--- Allow drop of actor directly into weapons list on Vehicle sheet to assign as Gunner.

--- a/css/journal.css
+++ b/css/journal.css
@@ -443,6 +443,7 @@ a.torg-inline-buff {
   margin-right: 0.5rem;
   width: 50%;
   height: 50%;
+  object-fit: cover;
 
   &.shrink20p {
     width: 20%;
@@ -462,6 +463,7 @@ a.torg-inline-buff {
   margin-left: 0.5rem;
   width: 50%;
   height: 50%;
+  object-fit: cover;
 
   &.shrink20p {
     width: 20%;

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -3534,8 +3534,12 @@ p.skill-chat-title.skilled {
     }
   }
 
+  .sheet-content .main-content {
+    display: flex;
+    flex-direction: column;
+  }
+
   .window-content .editor {
-    --min-height: 400px;
     border: 15px solid transparent;
     border-image: url('../images/frameWithoutFilling.svg') 30 / 2rem;
   }
@@ -3570,11 +3574,36 @@ p.skill-chat-title.skilled {
     resize: none;
     padding: 5px 5px;
     width: 100%;
-    /*height: 100%;*/
-  }
+    flex: 1;
 
-  .window-content .editor[name="system.prerequisites"] {
-    min-height: 150px;
+    &[name="system.description"] {
+      --min-height: 300px;
+      flex: 3;
+    }
+
+    &[name="system.prerequisites"] {
+      min-height: 150px;
+      row-gap: 0px;
+
+      menu {
+        gap: 2px;
+        padding: 4px;
+
+        li.text button {
+          --button-size: 24px;
+          font-size: 10px;
+          padding: 0.25em;
+        }
+      }
+
+      .editor-container {
+        margin-top: 0px;
+
+        .editor-content {
+          padding: 0px;
+        }
+      }
+    }
   }
 
   .window-content .effects {

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -4169,7 +4169,7 @@ h4 {
   font-weight: normal;
 }
 
-.sheet.item.miracle p.atkDmgAP {
+.sheet.item .item-data-label.atkDmgAP {
   font-size: smaller;
 }
 

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -4220,6 +4220,10 @@ dialog.externalLinks {
 
 div.token-distance {
   background-color: #000060;
+
+  span.total-measurement {
+    color: white;
+  }
 }
 
 a.torg-inline-check,

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -3407,7 +3407,7 @@ p.skill-chat-title.skilled {
   .window-content .sheet-content {
     display: grid;
     grid-template-columns: 150px 1fr;
-    margin: 15px;
+    margin-bottom: 1em;
     column-gap: 0.5em;
   }
 

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -2976,7 +2976,7 @@ div.readme a.compendium {
     padding: 0px 0px;
   }
 
-  .item-description-chat {
+  .item-description {
     font-family: Palatino;
     background-image: none;
     background-color: transparent;
@@ -3567,7 +3567,7 @@ p.skill-chat-title.skilled {
     }
   }
 
-  .window-content .item-description-textarea {
+  .window-content .item-description {
     font-family: "Palatino Linotype";
     font-size: 14px;
     border-radius: 15px;
@@ -3581,7 +3581,7 @@ p.skill-chat-title.skilled {
       flex: 3;
     }
 
-    &[name="system.prerequisites"] {
+    &.smallEditor {
       min-height: 150px;
       row-gap: 0px;
 

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -3390,8 +3390,7 @@ p.skill-chat-title.skilled {
 
   .window-content .sheet-content {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: repeat(3, 1fr);
+    grid-template-columns: 150px 1fr;
     margin: 15px;
     column-gap: 0.5em;
   }
@@ -3467,8 +3466,6 @@ p.skill-chat-title.skilled {
   }
 
   .window-content .asside {
-    grid-row: 1/4;
-    grid-column: 1/2;
     text-align: center;
 
     &.armor {
@@ -3517,11 +3514,6 @@ p.skill-chat-title.skilled {
       text-align: center;
       max-width: 150px;
     }
-  }
-
-  .window-content .main-content {
-    grid-row: 1/4;
-    grid-column: 2/5;
   }
 
   .window-content .editor {

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -2714,14 +2714,27 @@ nav#controls,
   button {
     border-width: 0px;
     height: 24px;
+    /* .themed .theme-dark */
+    --control-bg-color: var(--color-cool-5-75);
+    --control-border-color: var(--color-cool-4);
+    --control-icon-color: var(--color-light-2);
+    --control-hover-bg-color: var(--color-cool-5);
+    --control-hover-border-color: var(--color-cool-3);
+    --control-hover-icon-color: var(--color-light-1);
+    --control-active-bg-color: var(--color-cool-5);
+    --control-active-border-color: var(--color-warm-2);
+    --control-active-icon-color: var(--color-light-1);
+    --control-button-border-color: var(--color-warm-1);
+    --control-button-hover-bg-color: var(--color-warm-2);
+    --control-button-hover-border-color: var(--color-light-1);
   }
 
-  .heros-first,
+  .heroes-first,
   div.drama-heroes button {
     color: rgb(132, 132, 255);
   }
 
-  .vilains-first,
+  .villains-first,
   div.drama-villains button {
     color: rgb(253, 148, 148);
   }

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -425,8 +425,8 @@ dialog.torgeternity:not(.actor, .item) .window-content,
   }
 
   &:not(.minimized) {
-    min-width: 450px;
-    min-height: 636px;
+    min-width: 750px;
+    min-height: 400px;
   }
 
   --color-scrollbar: #227878;
@@ -439,14 +439,12 @@ dialog.torgeternity:not(.actor, .item) .window-content,
   .window-content {
     font-size: 13px;
     line-height: 14px;
-    /*background-image: url(../images/bg-sheet.webp);
-    background-size: cover;
-    padding-right: 0px;*/
 
     &>div.scrollable[data-application-part="vehicle"],
     &>div.scrollable[data-application-part="threat"] {
       padding-right: 10px;
       margin-right: 0px;
+      height: 100%;
     }
 
     h1 {

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -165,6 +165,7 @@ dialog.torgeternity:not(.actor, .item) .window-content,
 
 .item.sheet.torgeternity .tab {
   font-family: Palatino;
+  height: 100%;
 }
 
 .item.sheet.torgeternity .window-content header.sheet-header {
@@ -3409,6 +3410,7 @@ p.skill-chat-title.skilled {
     grid-template-columns: 150px 1fr;
     margin-bottom: 1em;
     column-gap: 0.5em;
+    height: 100%;
   }
 
   .window-content .raceDescriptionHeadline {
@@ -3533,7 +3535,7 @@ p.skill-chat-title.skilled {
   }
 
   .window-content .editor {
-    min-height: 400px;
+    --min-height: 400px;
     border: 15px solid transparent;
     border-image: url('../images/frameWithoutFilling.svg') 30 / 2rem;
   }
@@ -3568,6 +3570,7 @@ p.skill-chat-title.skilled {
     resize: none;
     padding: 5px 5px;
     width: 100%;
+    /*height: 100%;*/
   }
 
   .window-content .editor[name="system.prerequisites"] {

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -4260,3 +4260,17 @@ a.torg-inline-buff {
     margin-left: 10px;
   }
 }
+
+#hotbar #action-bar li.slot {
+  background: url(../images/backg-page.webp);
+  box-shadow: 0 0 5px #000 inset;
+  border-radius: 0% 0% 75%;
+
+  &.full {
+    border-radius: 10%;
+  }
+
+  &:hover {
+    box-shadow: 0 0 10px #004777 inset;
+  }
+}

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -1772,7 +1772,7 @@ dialog.torgeternity:not(.actor, .item) .window-content,
   }
 }
 
-.tabsOff .sheet.actor .window-content {
+.sheet.actor.tabsOff .window-content {
   nav.tabs {
     display: none;
   }
@@ -1782,7 +1782,7 @@ dialog.torgeternity:not(.actor, .item) .window-content,
   }
 }
 
-.tabsOn .sheet.actor .window-content h5.editable-tooltip {
+.sheet.actor.tabsOn .window-content h5.editable-tooltip {
   display: none;
 }
 

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -2740,6 +2740,11 @@ nav#controls,
     width: 65px;
   }
 
+  .player-dsr-counter {
+    flex: 0;
+    margin-right: 2em;
+  }
+
   .player-dsr-token {
     color: black;
     font-family: Palatino;

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -3997,6 +3997,14 @@ form.cards-config {
   font-size: 10px;
 }
 
+#GMscreen {
+  overflow: visible;
+
+  .window-content {
+    overflow: visible;
+  }
+}
+
 #gm-screen {
   position: absolute;
   width: 120%;

--- a/lang/en.json
+++ b/lang/en.json
@@ -742,6 +742,10 @@
         "hint": "The tint colour for grid cells when a token has exceeded its max move (default: --color-level-error)",
         "name": "Grid Highlight (> Run)"
       },
+      "showMovementRuler": {
+        "hint": "Displays the movement history of tokens during a combat round (history is cleared on a new round)",
+        "name": "Show Token Movement History"
+      },
       "autoShock": {
         "name": "Automatically Apply KO",
         "hint": "Automatically set an actor to unconscious whenever their shock is exceeded"

--- a/module/GMScreen.js
+++ b/module/GMScreen.js
@@ -6,8 +6,9 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api
 export default class GMScreen extends HandlebarsApplicationMixin(ApplicationV2) {
 
   static DEFAULT_OPTIONS = {
-    tag: 'form',
-    classes: ['torgeternity', 'gmscreen', 'themed', 'theme-dark'],
+    //tag: 'form',
+    id: "GMscreen",
+    classes: ['torgeternity', 'themed', 'theme-dark'],
     position: {
       top: 10,
       width: 1300,
@@ -15,7 +16,8 @@ export default class GMScreen extends HandlebarsApplicationMixin(ApplicationV2) 
     },
     window: {
       resizable: true,
-      contentClasses: ['standard-form'],
+      //contentClasses: ['standard-form'],
+      title: 'torgeternity.gmScreen.title',
     },
     actions: {
       clickPanel: GMScreen.#clickPanel,
@@ -25,10 +27,6 @@ export default class GMScreen extends HandlebarsApplicationMixin(ApplicationV2) 
   static PARTS = {
     gmscreen: { template: 'systems/torgeternity/templates/gmscreen/screen.html' },
   };
-
-  get title() {
-    return game.i18n.localize('torgeternity.gmScreen.title');
-  }
 
   /**
    *

--- a/module/canvas/torgeternityToken.js
+++ b/module/canvas/torgeternityToken.js
@@ -83,7 +83,7 @@ export default class TorgEternityToken extends foundry.canvas.placeables.Token {
     html = foundry.utils.parseHTML(html);
     html.style.setProperty("--position-x", `${token.center.x}px`);
     // 50 to get text ABOVE the top of the token
-    html.style.setProperty("--position-y", `${token.center.y - 0.5 * token.h - (50 * canvas.dimensions.uiScale)}px`);
+    html.style.setProperty("--position-y", `${token.center.y - 0.6 * token.h - (50 * canvas.dimensions.uiScale)}px`);
     html.style.setProperty("--ui-scale", canvas.dimensions.uiScale);
 
     // Update the displayed label

--- a/module/canvas/torgeternityToken.js
+++ b/module/canvas/torgeternityToken.js
@@ -1,3 +1,5 @@
+import TorgeternityActor from '../documents/actor/torgeternityActor.js';
+
 export default class TorgEternityToken extends foundry.canvas.placeables.Token {
 
   static #originToken;
@@ -10,7 +12,7 @@ export default class TorgEternityToken extends foundry.canvas.placeables.Token {
     if (!game.settings.get('torgeternity', 'hoverDistance') || !this.visible) return result;
     if (!canvas.tokens.active || game.activeTool !== "select") return result;
 
-    const originActor = game.user.character;
+    const originActor = TorgeternityActor.getControlledActor();
     if (!originActor) return result;
     const originToken = canvas.scene.tokens.find(t => t.actor === originActor);
     if (!originToken || originToken.object === this) return;

--- a/module/controlButtons.js
+++ b/module/controlButtons.js
@@ -1,3 +1,5 @@
+import TorgeternityActor from './documents/actor/torgeternityActor.js';
+
 /**
  *
  */
@@ -25,7 +27,7 @@ export default function initTorgControlButtons() {
           icon: 'fa fa-id-badge',
           toggle: true,
           onChange: (event, active) => {
-            const hand = game.user.character && game.user.character.getDefaultHand();
+            const hand = TorgeternityActor.getControlledActor()?.getDefaultHand();
             if (!hand) return ui.notifications.error(game.i18n.localize('torgeternity.notifications.noHands'));
             setWindowState(hand.sheet, active);
           },
@@ -91,10 +93,10 @@ Hooks.on('closeGMScreen', () => setControlsToggle("gmScreen", false))
 Hooks.on('closeMacroHub', () => setControlsToggle("macroHub", false))
 
 Hooks.on('rendertorgeternityPlayerHand', (hand, element, context, options) => {
-  const ownHand = game.user.character && game.user.character.getDefaultHand();
+  const ownHand = TorgeternityActor.getControlledActor()?.getDefaultHand();
   if (hand.document === ownHand) setControlsToggle("playerHand", true)
 })
 Hooks.on('closetorgeternityPlayerHand', (hand) => {
-  const ownHand = game.user.character && game.user.character.getDefaultHand();
+  const ownHand = TorgeternityActor.getControlledActor()?.getDefaultHand();
   if (hand.document === ownHand) setControlsToggle("playerHand", false)
 })

--- a/module/data/item/general.js
+++ b/module/data/item/general.js
@@ -1,5 +1,6 @@
 import { getTorgValue } from '../../torgchecks.js';
 import { BaseItemData } from './baseItemData.js'
+import { calcPriceValue } from '../shared.js';
 
 const fields = foundry.data.fields;
 /**
@@ -28,26 +29,6 @@ export class GeneralItemData extends BaseItemData {
    */
   prepareBaseData() {
     super.prepareBaseData();
-    // Calculate this.value based on this.price
-    let found = this.price?.match(/^(\d+)(\D*)$/);
-    if (!found) {
-      this.value = null;
-    } else {
-      let price = Number(found[1]);
-      if (found[2]) {
-        const units = found[2];
-        if (units === CONFIG.torgeternity.magnitudeLabels.billions) {
-          price *= 1000000000;
-        } else if (units === CONFIG.torgeternity.magnitudeLabels.millions) {
-          price *= 1000000;
-        } else if (units === CONFIG.torgeternity.magnitudeLabels.thousands) {
-          price *= 1000;
-        } else {
-          // Unknown suffix, so don't generate a value
-          price = null;
-        }
-      }
-      this.value = price ? getTorgValue(price) : null;
-    }
+    this.value = calcPriceValue(this.price);
   }
 }

--- a/module/data/shared.js
+++ b/module/data/shared.js
@@ -1,3 +1,5 @@
+import { getTorgValue } from '../torgchecks.js';
+
 /**
  *
  * @param {boolean} unskilledUse Can the skill be used unskilled?
@@ -28,4 +30,24 @@ export function migrateCosm(cosm) {
 
   console.log(`Invalid Cosm: ${cosm}`);
   return 'none';
+}
+
+export function calcPriceValue(price) {
+  const found = price?.match(/^(\d+)(\D*)$/);
+  if (!found) return null;
+  let fullprice = Number(found[1]);
+  if (found[2]) {
+    const units = found[2];
+    if (units === CONFIG.torgeternity.magnitudeLabels.billions) {
+      fullprice *= 1000000000;
+    } else if (units === CONFIG.torgeternity.magnitudeLabels.millions) {
+      fullprice *= 1000000;
+    } else if (units === CONFIG.torgeternity.magnitudeLabels.thousands) {
+      fullprice *= 1000;
+    } else {
+      // Unknown suffix, so don't generate a value
+      fullprice = null;
+    }
+  }
+  return fullprice ? getTorgValue(fullprice) : null;
 }

--- a/module/documents/actor/torgeternityActor.js
+++ b/module/documents/actor/torgeternityActor.js
@@ -43,7 +43,8 @@ export default class TorgeternityActor extends foundry.documents.Actor {
       this.system.other.maxDex = wornArmor?.system?.maxDex ?? 0;
       const highestMinStrWeapons = Math.max(...this.equippedMelees?.map((m) => m.system.minStrength)) ?? 0;
       this.system.other.minStr = Math.max(wornArmor?.system?.minStrength ?? 0, highestMinStrWeapons);
-      // TODO: If we allow more than 1 wornArmor and an array is to be expected, then we need to change that here
+      // TODO: If we allow more than 1 wornArmor and an array is to be expected, then we need to change that here.
+      // value of each field is set in prepareDerivedData
       this.defenses = {
         dodge: { value: 0, mod: shieldBonus },
         meleeWeapons: { value: 0, mod: shieldBonus },
@@ -57,24 +58,26 @@ export default class TorgeternityActor extends foundry.documents.Actor {
         shield: shieldBonus
       };
       this.unarmed = { damage: 0, damageMod: 0 };
-    }
 
-    if (this.type === 'stormknight') {
-      if (this.race) {
-        for (const attribute of Object.keys(this.race.system.attributeMaximum)) {
-          this.system.attributes[attribute].maximum = this.race.system.attributeMaximum[attribute];
+      if (this.type === 'stormknight') {
+        if (this.race) {
+          for (const attribute of Object.keys(this.race.system.attributeMaximum)) {
+            this.system.attributes[attribute].maximum = this.race.system.attributeMaximum[attribute];
+          }
+          this.system.details.race = this.race.name;
+        } else {
+          this.system.details.race = game.i18n.localize('torgeternity.sheetLabels.noRace');
         }
-        this.system.details.race = this.race.name;
-      } else {
-        this.system.details.race = game.i18n.localize('torgeternity.sheetLabels.noRace');
       }
-    }
-    if (this.type === 'vehicle') {
+
+    } else {
+      // vehicle
       this.defenses = {
         toughness: this.system.toughness,
         armor: this.system.armor,
       };
     }
+
     this.statusModifiers = {
       stymied: 0,
       vulnerable: 0,
@@ -93,13 +96,7 @@ export default class TorgeternityActor extends foundry.documents.Actor {
     this.statusModifiers = {
       stymied: this.statuses.has('veryStymied') ? -4 : this.statuses.has('stymied') ? -2 : 0,
       vulnerable: this.statuses.has('veryVulnerable') ? 4 : this.statuses.has('vulnerable') ? 2 : 0,
-      darkness: this.statuses.has('pitchBlack')
-        ? -6
-        : this.statuses.has('dark')
-          ? -4
-          : this.statuses.has('dim')
-            ? -2
-            : 0,
+      darkness: this.statuses.has('pitchBlack') ? -6 : this.statuses.has('dark') ? -4 : this.statuses.has('dim') ? -2 : 0,
     };
 
     // Skillsets
@@ -140,8 +137,7 @@ export default class TorgeternityActor extends foundry.documents.Actor {
       this.defenses.meleeWeapons.value = meleeWeaponsDefenseSkill + this.defenses.meleeWeapons.mod;
 
       const unarmedCombatDefenseSkill = skills.unarmedCombat.value || attributes.dexterity.value;
-      this.defenses.unarmedCombat.value =
-        unarmedCombatDefenseSkill + this.defenses.unarmedCombat.mod;
+      this.defenses.unarmedCombat.value = unarmedCombatDefenseSkill + this.defenses.unarmedCombat.mod;
 
       const intimidationDefenseSkill = skills.intimidation.value || attributes.spirit.value;
       this.defenses.intimidation.value = intimidationDefenseSkill + this.defenses.intimidation.mod;

--- a/module/documents/actor/torgeternityActor.js
+++ b/module/documents/actor/torgeternityActor.js
@@ -480,7 +480,7 @@ export default class TorgeternityActor extends foundry.documents.Actor {
             lockRotation: true,
             rotation: 0,
             texture: {
-              src: 'systems/torgeternity/images/characters/threat-generic.Token.webp',
+              src: data.img ?? 'systems/torgeternity/images/characters/threat-generic.Token.webp',
               rotation: 0,
             },
             displayBars: CONST.TOKEN_DISPLAY_MODES.HOVER,

--- a/module/documents/actor/torgeternityActor.js
+++ b/module/documents/actor/torgeternityActor.js
@@ -13,10 +13,6 @@ export default class TorgeternityActor extends foundry.documents.Actor {
    *
    * @returns {Item|null}
    */
-  get wornArmor() {
-    return this.itemTypes.armor.find((a) => a.system.equipped) ?? null;
-  }
-
   get equippedMelee() {
     return this.itemTypes.meleeweapon.find((a) => a.system.equipped) ?? null;
   }
@@ -39,25 +35,26 @@ export default class TorgeternityActor extends foundry.documents.Actor {
   prepareBaseData() {
     // Here Effects are not yet applied
     if (this.type !== 'vehicle') {
-      // initialize the worn armor bonus
-      this.fatigue = 2 + (this.wornArmor?.system?.fatigue ?? 0);
-      this.system.other.maxDex = this.wornArmor?.system?.maxDex ?? 0;
-      const highestMinStrWeapons =
-        Math.max(...this.equippedMelees?.map((m) => m.system.minStrength)) ?? 0;
-      this.system.other.minStr = Math.max(
-        this.wornArmor?.system?.minStrength ?? 0,
-        highestMinStrWeapons ?? 0
-      ); // TODO: If we allow more than 1 wornArmor and an array is to be expected, then we need to change that here
+      // initialize the worn armor and shield bonus
+      const wornArmor = this.itemTypes.armor.find((a) => a.system.equipped);
+      const shieldBonus = this.itemTypes.shield.find((a) => a.system.equipped)?.system?.bonus ?? 0;
+
+      this.fatigue = 2 + (wornArmor?.system?.fatigue ?? 0);
+      this.system.other.maxDex = wornArmor?.system?.maxDex ?? 0;
+      const highestMinStrWeapons = Math.max(...this.equippedMelees?.map((m) => m.system.minStrength)) ?? 0;
+      this.system.other.minStr = Math.max(wornArmor?.system?.minStrength ?? 0, highestMinStrWeapons);
+      // TODO: If we allow more than 1 wornArmor and an array is to be expected, then we need to change that here
       this.defenses = {
-        dodge: { value: 0, mod: 0 },
-        meleeWeapons: { value: 0, mod: 0 },
+        dodge: { value: 0, mod: shieldBonus },
+        meleeWeapons: { value: 0, mod: shieldBonus },
         unarmedCombat: { value: 0, mod: 0 },
         intimidation: { value: 0, mod: 0 },
         maneuver: { value: 0, mod: 0 },
         taunt: { value: 0, mod: 0 },
         trick: { value: 0, mod: 0 },
         toughness: this.system.attributes.strength.value,
-        armor: this.wornArmor?.system?.bonus ?? 0,
+        armor: wornArmor?.system?.bonus ?? 0,
+        shield: shieldBonus
       };
       this.unarmed = { damage: 0, damageMod: 0 };
     }

--- a/module/documents/actor/torgeternityActor.js
+++ b/module/documents/actor/torgeternityActor.js
@@ -37,14 +37,18 @@ export default class TorgeternityActor extends foundry.documents.Actor {
     if (this.type !== 'vehicle') {
       // initialize the worn armor and shield bonus
       const wornArmor = this.itemTypes.armor.find((a) => a.system.equipped);
-      const shieldBonus = this.itemTypes.shield.find((a) => a.system.equipped)?.system?.bonus ?? 0;
+      const heldShield = this.itemTypes.shield.find((a) => a.system.equipped);
+      const shieldBonus = heldShield?.system?.bonus ?? 0;
 
       this.fatigue = 2 + (wornArmor?.system?.fatigue ?? 0);
       this.system.other.maxDex = wornArmor?.system?.maxDex ?? 0;
       const highestMinStrWeapons = Math.max(...this.equippedMelees?.map((m) => m.system.minStrength)) ?? 0;
-      this.system.other.minStr = Math.max(wornArmor?.system?.minStrength ?? 0, highestMinStrWeapons);
+      this.system.other.minStr = Math.max(
+        wornArmor?.system?.minStrength ?? 0,
+        heldShield?.system?.minStrength ?? 0,
+        highestMinStrWeapons);
       // TODO: If we allow more than 1 wornArmor and an array is to be expected, then we need to change that here.
-      // value of each field is set in prepareDerivedData
+      // 'value' of each field is set in prepareDerivedData
       this.defenses = {
         dodge: { value: 0, mod: shieldBonus },
         meleeWeapons: { value: 0, mod: shieldBonus },

--- a/module/documents/actor/torgeternityActor.js
+++ b/module/documents/actor/torgeternityActor.js
@@ -722,6 +722,15 @@ export default class TorgeternityActor extends foundry.documents.Actor {
     }
     return super.migrateData(source);
   }
+
+  /**
+   * For a Player, returns the controlled character.
+   * For a GM, returns the "first" selected (not targeted) token's actor.
+   * @returns Actor | null
+   */
+  static getControlledActor() {
+    return (game.user.isGM && game.canvas.tokens.controlled?.length) ? game.canvas.tokens.controlled[0].actor : game.user.character;
+  }
 }
 
 

--- a/module/dramaticScene/torgeternityCombat.js
+++ b/module/dramaticScene/torgeternityCombat.js
@@ -158,7 +158,10 @@ export default class TorgCombat extends Combat {
       const initiative = (combatant.token.disposition === whoFirst) ? 2 : 1;
       updates.push({ _id: combatant.id, initiative });
     }
-    if (updates.length) return this.updateEmbeddedDocuments("Combatant", updates, { turnEvents: false });
+    if (updates.length) {
+      await this.updateEmbeddedDocuments("Combatant", updates, { turnEvents: false });
+      this.setupTurns();
+    }
   }
 
   get conflictLineText() {
@@ -390,5 +393,15 @@ export default class TorgCombat extends Combat {
 
     // Cancel effects from previous card (if any)
     return this.setDramaEffects(prevActiveCard);
+  }
+
+  // Sort by initiative, and then by name.
+  _sortCombatants(a, b) {
+    const ia = Number.isNumeric(a.initiative) ? a.initiative : -Infinity;
+    const ib = Number.isNumeric(b.initiative) ? b.initiative : -Infinity;
+    if (ia === ib)
+      return (a.name < b.name) ? -1 : 1;
+    else
+      return (ib - ia) || (a.id > b.id ? 1 : -1);
   }
 }

--- a/module/enrichers.js
+++ b/module/enrichers.js
@@ -141,6 +141,9 @@ function _onClickInlineCheck(event) {
  * INLINE CONDITIONS
  * 
  * @Condition[status]{label}
+ * @Condition[status|overlay|on]{label}
+ * @Condition[status|off]{label}
+ * @Condition[status|on]{label}
  */
 const InlineConditionPattern = /@Condition\[(.+?)\](?:\{(.+?)\}){0,1}/g;
 
@@ -151,9 +154,8 @@ function InlineConditionEnricher(match, options) {
 
   // Decode each of the parameters
   const dataset = { status };
-  for (const elem of parts) {
-    const [key, value] = elem.split("=");
-    dataset[key] = value ?? true;
+  for (const key of parts) {
+    dataset[key] = true;
   }
 
   // Create the base anchor
@@ -188,10 +190,10 @@ async function _onClickInlineCondition(event) {
 
   const data = { ...target.dataset };
 
-  const options = { active: true };
-  if (Object.hasOwn(data, "toggle")) delete options.active;
-  if (Object.hasOwn(data, "active")) options.active = data.active;
-  if (Object.hasOwn(data, "overlay")) options.overlay = data.overlay;
+  const options = {};
+  if (Object.hasOwn(data, "off")) options.active = false;
+  else if (!Object.hasOwn(data, "toggle")) options.active = true;
+  if (Object.hasOwn(data, "overlay")) options.overlay = true;
 
   // Special case of stymied/vulnerable stacking
   for (const actor of getActors()) {

--- a/module/enrichers.js
+++ b/module/enrichers.js
@@ -258,7 +258,7 @@ function InlineBuffEnricher(match, options) {
   }
 
   if (!found) {
-    console.warn(`Unrecognised @Buff key: ${skillAttribute}`)
+    console.warn(`Unrecognised @Buff key: ${match[1]}`)
     return match[0];
   }
 

--- a/module/keybinding.js
+++ b/module/keybinding.js
@@ -1,4 +1,6 @@
 import { PossibilityByCosm } from './possibilityByCosm.js';
+import TorgeternityActor from './documents/actor/torgeternityActor.js';
+
 /**
  *
  */
@@ -8,9 +10,7 @@ export default function createTorgShortcuts() {
     name: game.i18n.localize('torgeternity.dialogPrompts.openHand'),
     editable: [{ key: 'KeyH', },],
     onDown: (context) => {
-      if (game.user.character) {
-        game.user.character.getDefaultHand().sheet.toggleRender();
-      }
+      TorgeternityActor.getControlledActor()?.getDefaultHand().sheet.toggleRender();
     },
   });
   game.keybindings.register('torgeternity', 'openGMScreen', {
@@ -24,9 +24,8 @@ export default function createTorgShortcuts() {
     name: 'Possibility by cosm', // game.i18n.localize("torgeternity.gmScreen.toggle"),
     editable: [{ key: 'KeyP', },],
     onDown: (context) => {
-      if (game.user.character) {
-        PossibilityByCosm.toggleRender(game.user.character);
-      }
+      const actor = TorgeternityActor.getControlledActor();
+      if (actor) PossibilityByCosm.toggleRender(actor);
     },
   });
 }

--- a/module/macros.js
+++ b/module/macros.js
@@ -727,14 +727,8 @@ export class TorgeternityMacros {
       newEffect.tint = bonus < 0 ? '#ff0000' : '#00ff00';
       newEffect.icon = bonus < 0 ? 'icons/svg/downgrade.svg' : 'icons/svg/upgrade.svg';
     }
-    const actors = [];
-    if (game.canvas.tokens.controlled.length > 0) {
-      for (const token of game.canvas.tokens.controlled) {
-        actors.push(token.actor);
-      }
-    } else {
-      actors.push(game.user.character);
-    }
+    let actors = game.canvas.tokens.controlled.map(t => t.actor);
+    if (!actors.length) actors = [game.user.character];
 
     for (const actor of actors) {
       await actor?.createEmbeddedDocuments('ActiveEffect', [newEffect]);

--- a/module/macros.js
+++ b/module/macros.js
@@ -739,12 +739,12 @@ export class TorgeternityMacros {
    * Applies damage on targeted tokens
    *
    * @param {string} source A description of the source the damage comes from
-              * @param {number} value The actual damage value
-              * @param {number} bds The number of Bonus Dice that ought to take place.
-              * @param {boolean} armored Does armor count?
-              * @param {number} ap The amount of armor piercing.
-              * @returns {null} no Value
-              */
+   * @param {number} value The actual damage value
+   * @param {number} bds The number of Bonus Dice that ought to take place.
+   * @param {boolean} armored Does armor count?
+   * @param {number} ap The amount of armor piercing.
+   * @returns {null} no Value
+   */
   async periculum(source = '', value = 10, bds = 0, armored = false, ap = 0) {
     if (!game.user.targets.size)
       return ui.notifications.warn(game.i18n.localize('torgeternity.notifications.noTarget'));

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -201,8 +201,7 @@ export async function torgMigration() {
         for (const key of badActorTokenKeys) {
           if (
             key === 'systems\\torgeternity\\images\\icons\\threat.Token.webp' &&
-            actor.prototypeToken.texture.src ===
-            'systems\\torgeternity\\images\\icons\\threat.Token.webp'
+            actor.prototypeToken.texture.src === 'systems\\torgeternity\\images\\icons\\threat.Token.webp'
           ) {
             const goodKey = 'systems\\torgeternity\\images\\characters\\threat-generic.Token.webp';
             await actor.update({ 'prototypeToken.texture.src': goodKey });

--- a/module/settings.js
+++ b/module/settings.js
@@ -244,6 +244,19 @@ export function registerTorgSettings() {
     default: true
   });
 
+  game.settings.register('torgeternity', 'showMovementRuler', {
+    name: 'torgeternity.settingMenu.showMovementRuler.name',
+    hint: 'torgeternity.settingMenu.showMovementRuler.hint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: true,
+    requiresReload: true,
+  });
+  // Disable TokenRuler if not required
+  if (!game.settings.get('torgeternity', 'showMovementRuler'))
+    CONFIG.Token.rulerClass = null;
+
   game.settings.register('torgeternity', 'rulerGridWalk', {
     name: 'torgeternity.settingMenu.rulerGridWalk.name',
     hint: 'torgeternity.settingMenu.rulerGridWalk.hint',

--- a/module/sheets/torgeternityActorSheet.js
+++ b/module/sheets/torgeternityActorSheet.js
@@ -152,6 +152,9 @@ export default class TorgeternityActorSheet extends foundry.applications.api.Han
         break;
       case 'vehicle':
         options.parts = [this.actor.type];
+        if (options.isFirstRender) {
+          options.position.height = "auto";
+        }
         break;
       case 'threat':
         options.parts = [this.actor.type];

--- a/module/sheets/torgeternityItemSheet.js
+++ b/module/sheets/torgeternityItemSheet.js
@@ -297,44 +297,60 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
     // On first render, set the height
     if (options.isFirstRender) {
       switch (this.document.type) {
+        case 'ammunition':
+          options.position.height = 685;
+          break;
         case 'firearm':
+          options.position.height = 800;
+          break;
         case 'missileweapon':
-          options.position.height = 850;
+          options.position.height = 940;
           break;
         case 'heavyweapon':
-          options.position.height = 730;
+          options.position.height = 800;
           break;
         case 'meleeweapon':
-          options.position.height = 675;
+          options.position.height = 795;
           break;
         case 'miracle':
         case 'psionicpower':
         case 'spell':
-          options.position.height = 780;
+          options.position.height = 795;
           break;
         case 'specialability':
-          options.position.width = 435;
-          options.position.height = 585;
+          options.position.height = 580;
           break;
         case 'specialability-rollable':
-          options.position.height = 625;
+          options.position.height = 650;
           break;
         case 'vehicle':
-          options.position.height = 630;
-          break;
-        case 'implant':
-        case 'armor':
-        case 'shield':
-          options.position.height = 665;
-          break;
-        case 'customAttack':
           options.position.height = 675;
           break;
+        case 'implant':
+          options.position.height = 650;
+          break;
+        case 'armor':
+          options.position.height = 665;
+          break;
+        case 'shield':
+          options.position.height = 650;
+          break;
+        case 'customAttack':
+          options.position.height = 705;
+          break;
+        case 'customSkill':
+        case 'gear':
+          options.position.height = 580;
+          break;
         case 'vehicleAddOn':
-          options.position.height = 620;
-          options.position.width = 465;
+          options.position.height = 650;
           break;
         case 'perk':
+          options.position.height = 810;
+          break;
+        case 'race':
+          options.position.height = 860;
+          break;
         default:
           options.position.height = 600;
       }

--- a/module/sheets/torgeternityItemSheet.js
+++ b/module/sheets/torgeternityItemSheet.js
@@ -12,10 +12,6 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
       contentClasses: ['standard-form', 'scrollable'],
       resizable: true,
     },
-    position: {
-      width: 530,
-      height: 580,
-    },
     form: {
       submitOnChange: true
     },
@@ -288,70 +284,8 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
         break;
     }
 
-    // On first render, set the height
-    if (options.isFirstRender) {
-      if (!this.options.classes.includes(this.item.type))
-        this.options.classes.push(this.item.type);
-
-      switch (this.document.type) {
-        case 'ammunition':
-          options.position.height = 685;
-          break;
-        case 'firearm':
-          options.position.height = 800;
-          break;
-        case 'missileweapon':
-          options.position.height = 940;
-          break;
-        case 'heavyweapon':
-          options.position.height = 800;
-          break;
-        case 'meleeweapon':
-          options.position.height = 795;
-          break;
-        case 'miracle':
-        case 'psionicpower':
-        case 'spell':
-          options.position.height = 795;
-          break;
-        case 'specialability':
-          options.position.height = 580;
-          break;
-        case 'specialability-rollable':
-          options.position.height = 650;
-          break;
-        case 'vehicle':
-          options.position.height = 675;
-          break;
-        case 'implant':
-          options.position.height = 650;
-          break;
-        case 'armor':
-          options.position.height = 665;
-          break;
-        case 'shield':
-          options.position.height = 650;
-          break;
-        case 'customAttack':
-          options.position.height = 705;
-          break;
-        case 'customSkill':
-        case 'gear':
-          options.position.height = 580;
-          break;
-        case 'vehicleAddOn':
-          options.position.height = 660;
-          break;
-        case 'perk':
-          options.position.height = 810;
-          break;
-        case 'race':
-          options.position.height = 860;
-          break;
-        default:
-          options.position.height = 600;
-      }
-    }
+    if (!this.options.classes.includes(this.item.type))
+      this.options.classes.push(this.item.type);
   }
 
   async _preparePartContext(partId, context, options) {

--- a/module/sheets/torgeternityItemSheet.js
+++ b/module/sheets/torgeternityItemSheet.js
@@ -343,7 +343,7 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
           options.position.height = 580;
           break;
         case 'vehicleAddOn':
-          options.position.height = 650;
+          options.position.height = 660;
           break;
         case 'perk':
           options.position.height = 810;

--- a/module/sheets/torgeternityItemSheet.js
+++ b/module/sheets/torgeternityItemSheet.js
@@ -169,18 +169,13 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
     }).bind(this.element);
 
     this.element.querySelectorAll('nav').forEach(nav => nav.classList.add("right-tab"));
-  }
 
-  /**
-   * Only triggered when the window is first rendered.
-   * @param {*} context 
-   * @param {*} options 
-   */
-  async _onFirstRender(context, options) {
-    // When the window is first opened, collapse the traits editor
-    const toggleButton = this.element.querySelector('a.toggleTraits');
-    if (toggleButton) TorgeternityItemSheet.#onToggleTraitEdit.call(this, null, toggleButton);
-    return super._onFirstRender(context, options);
+    if (options.force) {
+      // Either window has just been opened, or it has been brought to the top of the stack.
+      // When the window is first opened, collapse the traits editor
+      const toggleButton = this.element.querySelector('a.toggleTraits');
+      if (toggleButton) TorgeternityItemSheet.#onToggleTraitEdit.call(this, null, toggleButton);
+    }
   }
 
   /**

--- a/module/sheets/torgeternityItemSheet.js
+++ b/module/sheets/torgeternityItemSheet.js
@@ -274,7 +274,6 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
 
   _configureRenderOptions(options) {
     super._configureRenderOptions(options);
-    this.options.classes.push(this.item.type);
 
     // Decide which tabs are required
     switch (this.document.type) {
@@ -291,6 +290,9 @@ export default class TorgeternityItemSheet extends foundry.applications.api.Hand
 
     // On first render, set the height
     if (options.isFirstRender) {
+      if (!this.options.classes.includes(this.item.type))
+        this.options.classes.push(this.item.type);
+
       switch (this.document.type) {
         case 'ammunition':
           options.position.height = 685;

--- a/module/torgeternity.js
+++ b/module/torgeternity.js
@@ -333,6 +333,10 @@ Hooks.on('ready', async function () {
   // adding gmScreen to UI
   ui.GMScreen = new GMScreen();
 
+  // Set default time for combat (in seconds)
+  CONFIG.time.turnTime = 0;
+  CONFIG.time.roundTime = 10;
+
   // -----applying GM possibilities pool if absent
   if (game.user.isGM && !game.user.getFlag('torgeternity', 'GMpossibilities')) {
     game.user.setFlag('torgeternity', 'GMpossibilities', 0);

--- a/module/torgeternity.js
+++ b/module/torgeternity.js
@@ -861,7 +861,7 @@ function TorgRadioBoxesNumber(name, choices, options) {
     input.type = "radio";
     input.name = name;
     input.value = key;
-    if (isChecked) input.defaultChecked = (checked === key);
+    if (isChecked) input.defaultChecked = (checked == key);
     if (isNumber) input.dataset.dtype = "Number";
     if (options.hash.tooltip) element.dataset.tooltip = key;
     element.append(input, " ", label);

--- a/module/torgeternityChatLog.js
+++ b/module/torgeternityChatLog.js
@@ -3,6 +3,7 @@ import { rollBonusDie } from './torgchecks.js';
 import { torgDamage } from './torgchecks.js';
 import { TestResult, soakDamages } from './torgchecks.js';
 import { TestDialog } from './test-dialog.js';
+import TorgeternityActor from './documents/actor/torgeternityActor.js';
 
 const { DialogV2 } = foundry.applications.api;
 
@@ -78,8 +79,8 @@ export default class TorgeternityChatLog extends foundry.applications.sidebar.ta
       return;
     }
     // check for actor possibility
-    // If vehicle roll, search for a character from the user
-    const possOwner = test.actorType === 'vehicle' ? game.user.character?.uuid : test.actor;
+    // If vehicle roll, search for a character from the user (operator or gunner)
+    const possOwner = test.actorType === 'vehicle' ? TorgeternityActor.getControlledActor()?.uuid : test.actor;
     let possPool;
     // If no valid possOwner, take possibilities from the GM
     if (possOwner) {

--- a/templates/actors/threat/main.hbs
+++ b/templates/actors/threat/main.hbs
@@ -35,4 +35,7 @@
       {{> "systems/torgeternity/templates/actors/threat/background.hbs"}}
     </div>
   </div>
+  <h5 class="editable-tooltip">{{localize "torgeternity.sheetLabels.editableTooltip"}}
+    <i class="fas fa-chevron-double-down"></i>
+  </h5>
 </div>

--- a/templates/actors/vehicle/stats.hbs
+++ b/templates/actors/vehicle/stats.hbs
@@ -51,12 +51,7 @@
             <span>{{document.defenses.toughness}}&lpar;{{document.defenses.armor}}&rpar;</span>
           </td>
           <td class="vehicle-stat">
-            <input name="system.price.dollars" type="number" value="{{document.system.price.dollars}}"
-              data-dtype="Number" />
-            <select name="system.price.magnitude">
-              {{selectOptions config.magnitudes selected=document.system.price.magnitude sort=true
-                localize=true}}
-            </select>
+            <input name="system.price.dollars" type="text" value="{{document.system.price.dollars}}" />
             ( {{document.system.price.value}} )
           </td>
         </tr>

--- a/templates/chat/armor-card.hbs
+++ b/templates/chat/armor-card.hbs
@@ -3,8 +3,8 @@
     <img src="{{img}}" data-tooltip="{{name}}" />
     <span>{{name}}</span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">{{system.cosm}}</div>
     <div class="item-dropdown-extras">{{system.price}} ({{system.value}})</div>
     <div class="item-dropdown-extras">{{localize 'torgeternity.gear.tl'}} {{system.techlevel}}</div>

--- a/templates/chat/customSkill-card.hbs
+++ b/templates/chat/customSkill-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="generalGear-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{data.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{data.description}}}</div>
   </div>
 
 </div>

--- a/templates/chat/enhancement-card.hbs
+++ b/templates/chat/enhancement-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="enhancement-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{localize "torgeternity.enhancements.enhances"}}
       {{system.perk}}

--- a/templates/chat/eternityshard-card.hbs
+++ b/templates/chat/eternityshard-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="eternityshard-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{system.cosm}}
     </div>

--- a/templates/chat/gear-card.hbs
+++ b/templates/chat/gear-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="generalGear-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{system.cosm}}
     </div>

--- a/templates/chat/implant-card.hbs
+++ b/templates/chat/implant-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="implant-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{system.cosm}}
     </div>

--- a/templates/chat/miracle-card.hbs
+++ b/templates/chat/miracle-card.hbs
@@ -1,33 +1,40 @@
 <div
   class="miracle-border sheet-card {{system.type}}"
-  data-type="{{system.type}}"  
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{system.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
+  <div class="item-description" data-item-id="{{_id}}">
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.axiom"}}:</span>
-      <span class="item-dropdown-extras">{{localize "torgeternity.attributes.spirit"}} {{system.axiom}}</span></div>
+      <span class="item-dropdown-extras">{{localize "torgeternity.attributes.spirit"}} {{system.axiom}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.skilllevel"}}:</span>
-      <span class="item-dropdown-extras">{{localize "torgeternity.skills.faith"}} {{system.skilllevel}}</span></div>
+      <span class="item-dropdown-extras">{{localize "torgeternity.skills.faith"}} {{system.skilllevel}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.castingtime"}}:</span>
-      <span class="item-dropdown-extras">{{system.castingtime}}</span></div>
+      <span class="item-dropdown-extras">{{system.castingtime}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.dn"}}:</span>
-      <span class="item-dropdown-extras">{{system.dnType}}</span></div>
+      <span class="item-dropdown-extras">{{system.dnType}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.range"}}:</span>
-      <span class="item-dropdown-extras">{{system.range}}</span></div>
+      <span class="item-dropdown-extras">{{system.range}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.duration"}}:</span>
-      <span class="item-dropdown-extras">{{system.duration}}</span></div>
+      <span class="item-dropdown-extras">{{system.duration}}</span>
+    </div>
     <br />
-    <div class="item-description-chat">{{{system.description}}}</div>
+    <div class="item-description">{{{system.description}}}</div>
     <br />
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.good"}}:</span>
-      <span class="item-description-chat">{{system.good}}</span></div>
+      <span class="item-description">{{system.good}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.outstanding"}}:</span>
-      <span class="item-description-chat">{{system.outstanding}}</span></div>
+      <span class="item-description">{{system.outstanding}}</span>
+    </div>
   </div>
 
 </div>

--- a/templates/chat/perk-card.hbs
+++ b/templates/chat/perk-card.hbs
@@ -1,21 +1,20 @@
 <div
   class="perk-border sheet-card {{type}}"
-  data-type="{{type}}"  
->
-<div class="generalHeader">  
-      <img src="{{img}}" data-tooltip="{{name}}"/>      
-      <span>
-        {{name}} {{#if system.generalContradiction}}&bigstar;{{/if}}
-      </span>
+  data-type="{{type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
+    <span>
+      {{name}} {{#if system.generalContradiction}}&bigstar;{{/if}}
+    </span>
   </div>
   <div data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}
-    {{#if system.generalContradiction}}
-    <span>
-    &bigstar;{{localize "torgeternity.chatText.mayCauseContradiction"}}
-    </span>
-    {{/if}}
-    
+    <div class="item-description">{{{system.description}}}
+      {{#if system.generalContradiction}}
+        <span>
+          &bigstar;{{localize "torgeternity.chatText.mayCauseContradiction"}}
+        </span>
+      {{/if}}
+
     </div>
   </div>
 </div>

--- a/templates/chat/psionicpower-card.hbs
+++ b/templates/chat/psionicpower-card.hbs
@@ -1,33 +1,40 @@
 <div
   class="psionicpower-border sheet-card {{system.type}}"
-  data-type="{{system.type}}"  
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{system.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
+  <div class="item-description" data-item-id="{{_id}}">
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.axiom"}}:</span>
-      <span class="item-dropdown-extras">{{localize "torgeternity.sheetLabels.social"}} {{system.axiom}}</span></div>
+      <span class="item-dropdown-extras">{{localize "torgeternity.sheetLabels.social"}} {{system.axiom}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.skilllevel"}}:</span>
-      <span class="item-dropdown-extras">{{system.translatedSkill}} {{system.skilllevel}}</span></div>
+      <span class="item-dropdown-extras">{{system.translatedSkill}} {{system.skilllevel}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.castingtime"}}:</span>
-      <span class="item-dropdown-extras">{{system.castingtime}}</span></div>
+      <span class="item-dropdown-extras">{{system.castingtime}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.dn"}}:</span>
-      <span class="item-dropdown-extras">{{system.dnType}}</span></div>
+      <span class="item-dropdown-extras">{{system.dnType}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.range"}}:</span>
-      <span class="item-dropdown-extras">{{system.range}}</span></div>
+      <span class="item-dropdown-extras">{{system.range}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.duration"}}:</span>
-      <span class="item-dropdown-extras">{{system.duration}}</span></div>
+      <span class="item-dropdown-extras">{{system.duration}}</span>
+    </div>
     <br />
-    <div class="item-description-chat">{{{system.description}}}</div>
+    <div class="item-description">{{{system.description}}}</div>
     <br />
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.good"}}:</span>
-      <span class="item-description-chat">{{system.good}}</span></div>
+      <span class="item-description">{{system.good}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.outstanding"}}:</span>
-      <span class="item-description-chat">{{system.outstanding}}</span></div>
+      <span class="item-description">{{system.outstanding}}</span>
+    </div>
   </div>
 
 </div>

--- a/templates/chat/shield-card.hbs
+++ b/templates/chat/shield-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="shield-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{system.cosm}}
     </div>

--- a/templates/chat/specialability-card.hbs
+++ b/templates/chat/specialability-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="generalGear-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-    <img src="{{img}}" data-tooltip="{{name}}"/>      
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
     <span>
       {{name}}
     </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
   </div>
 
 </div>

--- a/templates/chat/spell-card.hbs
+++ b/templates/chat/spell-card.hbs
@@ -1,33 +1,40 @@
 <div
   class="spell-border sheet-card {{system.type}}"
-  data-type="{{system.type}}"  
->
-  <div class="generalHeader">  
-        <img src="{{img}}" data-tooltip="{{name}}"/>      
-      <span>
-        {{name}}
-      </span>
+  data-type="{{system.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
+    <span>
+      {{name}}
+    </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
+  <div class="item-description" data-item-id="{{_id}}">
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.axiom"}}:</span>
-      <span class="item-dropdown-extras">{{localize "torgeternity.sheetLabels.magic"}} {{system.axiom}}</span></div>
+      <span class="item-dropdown-extras">{{localize "torgeternity.sheetLabels.magic"}} {{system.axiom}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.skilllevel"}}:</span>
-      <span class="item-dropdown-extras">{{system.translatedSkill}} {{system.skilllevel}}</span></div>
+      <span class="item-dropdown-extras">{{system.translatedSkill}} {{system.skilllevel}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.castingtime"}}:</span>
-      <span class="item-dropdown-extras">{{system.castingtime}}</span></div>
+      <span class="item-dropdown-extras">{{system.castingtime}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.dn"}}:</span>
-      <span class="item-dropdown-extras">{{system.dnType}}</span></div>
+      <span class="item-dropdown-extras">{{system.dnType}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.range"}}:</span>
-      <span class="item-dropdown-extras">{{system.range}}</span></div>
+      <span class="item-dropdown-extras">{{system.range}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.duration"}}:</span>
-      <span class="item-dropdown-extras">{{system.duration}}</span></div>
+      <span class="item-dropdown-extras">{{system.duration}}</span>
+    </div>
     <br />
-    <div class="item-description-chat">{{{system.description}}}</div>
+    <div class="item-description">{{{system.description}}}</div>
     <br />
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.good"}}:</span>
-      <span class="item-description-chat">{{system.good}}</span></div>
+      <span class="item-description">{{system.good}}</span>
+    </div>
     <div><span style="font-weight:bold">{{localize "torgeternity.powers.outstanding"}}:</span>
-      <span class="item-description-chat">{{system.outstanding}}</span></div>
+      <span class="item-description">{{system.outstanding}}</span>
+    </div>
   </div>
 
 </div>

--- a/templates/chat/vehicle-card.hbs
+++ b/templates/chat/vehicle-card.hbs
@@ -1,15 +1,14 @@
 <div
   class="generalGear-border sheet-card {{data.type}}"
-  data-type="{{data.type}}"
->
-  <div class="generalHeader">  
-      <img src="{{img}}" data-tooltip="{{name}}"/>      
-      <span>
-        {{name}}
-      </span>
+  data-type="{{data.type}}">
+  <div class="generalHeader">
+    <img src="{{img}}" data-tooltip="{{name}}" />
+    <span>
+      {{name}}
+    </span>
   </div>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
     <div class="item-dropdown-extras">
       {{system.cosm}}
     </div>

--- a/templates/chat/vehicleAddOn-card.hbs
+++ b/templates/chat/vehicleAddOn-card.hbs
@@ -1,8 +1,7 @@
 <div
   class="vehicleAddOn-border sheet-card {{data.type}}"
   data-type="{{data.type}}"
-  style="background-image: url('systems/torgeternity/images/bgparch.webp')"
->
+  style="background-image: url('systems/torgeternity/images/bgparch.webp')">
   <table style="border:none;background-color:transparent">
     <tr style="border:none">
       <td>
@@ -13,8 +12,8 @@
       </td>
     </tr>
   </table>
-  <div class="item-description-chat" data-item-id="{{_id}}">
-    <div class="item-description-chat">{{{system.description}}}</div>
+  <div class="item-description" data-item-id="{{_id}}">
+    <div class="item-description">{{{system.description}}}</div>
   </div>
 
 </div>

--- a/templates/items/ammunition-sheet.hbs
+++ b/templates/items/ammunition-sheet.hbs
@@ -46,7 +46,7 @@
     </div>
 
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -77,7 +77,7 @@
           type="text"
           value="{{item.system.notes}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/customAttack-sheet.hbs
+++ b/templates/items/customAttack-sheet.hbs
@@ -32,7 +32,7 @@
           type="text"
           value="{{item.system.chatNote}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/customSkill-sheet.hbs
+++ b/templates/items/customSkill-sheet.hbs
@@ -24,7 +24,7 @@
         data-tooltip="{{localize 'torgeternity.skillDialogs.favoredChoice'}}" />
     </div>
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/enhancement-sheet.hbs
+++ b/templates/items/enhancement-sheet.hbs
@@ -6,7 +6,7 @@
     </div>
     <div class="main-content">
       <!-- right column -->
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/eternityshard-sheet.hbs
+++ b/templates/items/eternityshard-sheet.hbs
@@ -32,7 +32,7 @@
 
     </div>
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/firearm-sheet.hbs
+++ b/templates/items/firearm-sheet.hbs
@@ -81,7 +81,7 @@
             type="text"
             value="{{item.system.chatNote}}" />
         </p>
-        <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+        <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
           @root.editable)}}
           value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
         {{> "systems/torgeternity/templates/items/ammunition-field.hbs"}}

--- a/templates/items/gear-sheet.hbs
+++ b/templates/items/gear-sheet.hbs
@@ -38,7 +38,7 @@
 
     </div>
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/heavyweapon-sheet.hbs
+++ b/templates/items/heavyweapon-sheet.hbs
@@ -77,7 +77,7 @@
           value="{{item.system.chatNote}}" />
       </p>
       <p class="item-data-label">{{localize "torgeternity.gear.description"}}</p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea"
+      <prose-mirror toggled name="system.description" class="item-description"
         style="padding: 0px 0px 0px 10px" {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       {{> "systems/torgeternity/templates/items/ammunition-field.hbs"}}

--- a/templates/items/implant-sheet.hbs
+++ b/templates/items/implant-sheet.hbs
@@ -47,7 +47,7 @@
           type="text"
           value="{{item.system.notes}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/meleeweapon-sheet.hbs
+++ b/templates/items/meleeweapon-sheet.hbs
@@ -74,7 +74,7 @@
           type="text"
           value="{{item.system.chatNote}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/missileweapon-sheet.hbs
+++ b/templates/items/missileweapon-sheet.hbs
@@ -84,7 +84,7 @@
           type="text"
           value="{{item.system.chatNote}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       {{> "systems/torgeternity/templates/items/ammunition-field.hbs"}}

--- a/templates/items/perk-sheet.hbs
+++ b/templates/items/perk-sheet.hbs
@@ -51,13 +51,13 @@
       <p style="min-height: 22px; height:auto;" class="item-data-label">
         {{localize "torgeternity.perks.description"}}
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       <p style="min-height: 22px; height:auto;" class="item-data-label">
         {{localize "torgeternity.perks.prerequisites"}}
       </p>
-      <prose-mirror toggled name="system.prerequisites" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.prerequisites" class="item-description smallEditor" {{disabled (not
         @root.editable)}}
         value="{{ item.system.prerequisites }}">{{{ prerequisites }}}</prose-mirror>
     </div>

--- a/templates/items/powers-sheet.hbs
+++ b/templates/items/powers-sheet.hbs
@@ -63,11 +63,9 @@
         {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.goodResult"}}</p>
-      <textarea name="system.good" class="item-description-textarea flex1">
-      {{item.system.good}}</textarea>
+      <textarea name="system.good" class="item-description-textarea">{{item.system.good}}</textarea>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.outstandingResult"}}</p>
-      <textarea name="system.outstanding" class="item-description-textarea">
-      {{item.system.outstanding}}</textarea>
+      <textarea name="system.outstanding" class="item-description-textarea">{{item.system.outstanding}}</textarea>
     </div>
   </div>
   </div>

--- a/templates/items/powers-sheet.hbs
+++ b/templates/items/powers-sheet.hbs
@@ -59,13 +59,13 @@
     </div>
     <div class="main-content">
       <p class="item-data-label">{{localize "torgeternity.gear.description"}}</p>
-      <prose-mirror name="system.description" class="item-description-textarea" toggled name="system.description"
+      <prose-mirror name="system.description" class="item-description" toggled name="system.description"
         {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.goodResult"}}</p>
-      <textarea name="system.good" class="item-description-textarea">{{item.system.good}}</textarea>
+      <textarea name="system.good" class="item-description">{{item.system.good}}</textarea>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.outstandingResult"}}</p>
-      <textarea name="system.outstanding" class="item-description-textarea">{{item.system.outstanding}}</textarea>
+      <textarea name="system.outstanding" class="item-description">{{item.system.outstanding}}</textarea>
     </div>
   </div>
   </div>

--- a/templates/items/powers-sheet.hbs
+++ b/templates/items/powers-sheet.hbs
@@ -63,15 +63,11 @@
         {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.goodResult"}}</p>
-      <div>
-        <textarea name="system.good" class="item-description-textarea">
-        {{item.system.good}}</textarea>
-      </div>
+      <textarea name="system.good" class="item-description-textarea flex1">
+      {{item.system.good}}</textarea>
       <p class="item-data-label">{{localize "torgeternity.sheetLabels.outstandingResult"}}</p>
-      <div>
-        <textarea name="system.outstanding" class="item-description-textarea">
-        {{item.system.outstanding}}</textarea>
-      </div>
+      <textarea name="system.outstanding" class="item-description-textarea">
+      {{item.system.outstanding}}</textarea>
     </div>
   </div>
   </div>

--- a/templates/items/race-sheet.hbs
+++ b/templates/items/race-sheet.hbs
@@ -2,7 +2,7 @@
   <div class="sheet-content">
     <div class="main-content" style="grid-column:1/5;">
       <h1 class="raceDescriptionHeadline">{{localize "torgeternity.sheetLabels.description"}}</h1>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/shield-sheet.hbs
+++ b/templates/items/shield-sheet.hbs
@@ -54,7 +54,7 @@
           type="text"
           value="{{item.system.notes}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/specialability-rollable-sheet.hbs
+++ b/templates/items/specialability-rollable-sheet.hbs
@@ -21,7 +21,7 @@
           type="text"
           value="{{item.system.chatNote}}" />
       </p>
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/specialability-sheet.hbs
+++ b/templates/items/specialability-sheet.hbs
@@ -4,7 +4,7 @@
       <a class="convert-rsa" data-action="convertRsa" data-item-id="{{item.id}}">Convert to Rollable</a>
     </div>
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea" {{disabled (not
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not
         @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/vehicle-sheet.hbs
+++ b/templates/items/vehicle-sheet.hbs
@@ -41,7 +41,7 @@
         value="{{item.system.tough}}" />
     </div>
     <div class="main-content">
-      <prose-mirror toggled name="system.description" class="item-description-textarea"
+      <prose-mirror toggled name="system.description" class="item-description"
         style="padding: 0px 0px 0px 10px" {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>

--- a/templates/items/vehicleAddOn-sheet.hbs
+++ b/templates/items/vehicleAddOn-sheet.hbs
@@ -1,6 +1,6 @@
 <section class="tab stats scrollable {{tab.cssClass}}" data-group="primary" data-tab="stats">
   <div class="sheet-content" style="display:flex">
-    <div class="item-description-textarea">
+    <div class="item-description">
       <p class="item-data-label">
         {{localize "torgeternity.gear.short-description"}}&nbsp;
         <input

--- a/templates/items/vehicleAddOn-sheet.hbs
+++ b/templates/items/vehicleAddOn-sheet.hbs
@@ -1,17 +1,15 @@
 <section class="tab stats scrollable {{tab.cssClass}}" data-group="primary" data-tab="stats">
-  <div class="main-content">
-    <div class="sheet-content">
-      <div style="grid-column: 1/5" class="item-description-textarea">
-        <p class="item-data-label">
-          {{localize "torgeternity.gear.short-description"}}&nbsp;
-          <input
-            name="system.short-description"
-            type="text"
-            value="{{item.system.short-description}}" />
-        </p>
-        <prose-mirror toggled name="system.description" {{disabled (not @root.editable)}}
-          value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
-      </div>
+  <div class="sheet-content" style="display:flex">
+    <div class="item-description-textarea">
+      <p class="item-data-label">
+        {{localize "torgeternity.gear.short-description"}}&nbsp;
+        <input
+          name="system.short-description"
+          type="text"
+          value="{{item.system.short-description}}" />
+      </p>
+      <prose-mirror toggled name="system.description" {{disabled (not @root.editable)}}
+        value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>
   </div>
 </section>

--- a/templates/sidebar/combat-tracker-header.hbs
+++ b/templates/sidebar/combat-tracker-header.hbs
@@ -85,10 +85,10 @@
       {{disabled (not (and @root.user.isGM combat.turns))}}>
     </button>
     {{#if user.isGM}}
-      <!--<button type="button" class="heros-first icon fa-solid fa-users" data-action="heroesFirst"
+      <!--<button type="button" class="heroes-first icon fa-solid fa-users" data-action="heroesFirst"
         data-tooltip="{{localize 'torgeternity.combat.herosTooltip'}}" {{disabled (not combat.turns)}}>
       </button>
-      <button type="button" class="vilains-first icon fa-solid fa-users" data-action="villainsFirst"
+      <button type="button" class="villains-first icon fa-solid fa-users" data-action="villainsFirst"
         data-tooltip="{{localize 'torgeternity.combat.vilainsTooltip'}}" {{disabled (not combat.turns)}}>
       </button>-->
       {{> dramaButtons faction=firstFaction condition=firstCondition}}


### PR DESCRIPTION
### IMPORTANT

- Remove Active Effects from Shields that modify the defense (dodge/melee weapons), since that is now automated.
- `@Condition[...]` has been simplified to have just three optional words
  - `@Condition[status]` adds the condition
  - `@Condition[status|off]` removes the condition
  - `@Condition[status|toggle]` toggle the on/off state of the condition
  - `@Condition[status|overlay]` adds the condition and displays it as an overlay
  - `@Condition[status|toggle|overlay]` toggle the on/off state of the condition, and if toggled to the on state then it will be an overlay

### Improvements

- #381: **Auto-apply the shield bonus** to Dodge and Melee Weapon defense (existing AE must be removed from items).
- Apply an equipped **Shield's Minimum Strength**.
- Change vehicle sheet to show **combined dollars+magnitude** field, to match the price field of Items.
- Vehicle sheet defaults to smaller height.
- Restore styling of **macro bar** from V12.x
- Ensure the current selections are visible when the Test Dialog is first opened.
- If a specific image is set during initial Threat creation, then use that image for the token instead of the default.
- Reinstate hiding tabs on Threat sheet when its height goes below 630px.
- **Open Player Hand/Distance Hover** now affect selected tokens for GMs (still controlled Actor's token for players).
- Set hover distance label text color to White, regardless of Foundry's interface light/dark setting.
- **GM Screen** pops out of the window once again.
- Set **combat turn time** to 10 seconds, to advance clock automatically at end of combat Turn.
- **Sort Combatants alphabetically** within their allegiance group.
- **Item Sheets** now automatically size themselves.
- **Distance to Token** label placed ABOVE the top resource bar.
- Add a game system setting to disable core Foundry's **Token Movement History** feature.

Fixes #359, fixes #381, fixes #544
Resolves #195, resolves #326