### PR TITLE
13.12.1 - fix bug with blank skill names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # TORG Eternity Changelog
 
+## 13.12.1
+
+- Fix the blank skill names in the Combat and Interaction parts of the skills list.
+
 ## 13.12.0
 
 ## Enhancements

--- a/module/sheets/torgeternityActorSheet.js
+++ b/module/sheets/torgeternityActorSheet.js
@@ -225,12 +225,14 @@ export default class TorgeternityActorSheet extends foundry.applications.api.Han
     this.actor.statuses.forEach(status => context.statusEffects[status] = true);
     context.showConditions = true;
 
+    for (const skill of Object.keys(context.document.system.skills))
+      context.document.system.skills[skill].localName = game.i18n.localize(`torgeternity.skills.${skill}`);
+
     context.otherSkills = Object.entries(context.document.system.skills)
       .filter(skill => skill[1].groupName === 'other')
       .map(skill => {
         return {
           name: skill[0],
-          localName: game.i18n.localize(`torgeternity.skills.${skill[0]}`),
           ...skill[1]
         }
       })


### PR DESCRIPTION
- Fix the blank skill names in the Combat and Interaction parts of the skills list.