### PR TITLE
Resize Vehicle sheet + Customisable cosms

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## NEXT
 
 - Description field of **Vehicle Add-On Item Sheet** resizes to fit the window.
-- **Custom Cosms** are getting closer to being possible:
+- #549: **Custom Cosms** are getting closer to being possible:
   - Search for `livingLand` in torgeternity.css, en.json and the *.js files to see what needs customising in your own code.
   - The hook `torgSetupCosms(config)` can be used to modify the available cosms (config contains `CONFIG.torgeternity`)
   - `CONFIG.torgeternity.cosmPossyIcons[cosm]` - full path to icon for scene icons

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,16 @@
 ## NEXT
 
 - Description field of **Vehicle Add-On Item Sheet** resizes to fit the window.
+- **Custom Cosms** are getting closer to being possible:
+  - Search for `livingLand` in torgeternity.css, en.json and the *.js files to see what needs customising in your own code.
+  - The hook `torgSetupCosms(config)` can be used to modify the available cosms (config contains `CONFIG.torgeternity`)
+  - `CONFIG.torgeternity.cosmPossyIcons[cosm]` - full path to icon for scene icons
+  - `CONFIG.torgeternity.cosmPossyLargeIcons[cosm]` - full path to icon for Cosm Possibilties dialog
+  - You will need to set up the translations and CSS appropriately (e.g. search for livingLand in existing .css and lang/en.json files and copy accordingly)
+    - CSS: `#scene-navigation .cosm-card .{cosmname} {background-image: url('path to cosm tent') }`
+    - LANG: `torgeternity.cosmDecks.{cosm}`, `torgeternity.cosms.{cosm}`, `torgeternity.cosms.{cosm}PossLink`, `torgeternity.cosms.{cosm}PossLink2`
+  - Update game setting `('torgeternity', 'deckSetting')` with your own decks for your own realms (settings.js)
+  - Note that when dragging a Threat actor onto the scene, if the the token image path start with `systems/torgeternity/images/characters/threat` then it will get renamed to `threat-{cosm}`
 
 ## 13.12.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # TORG Eternity Changelog
 
+## NEXT
+
+- Description field of **Vehicle Add-On Item Sheet** resizes to fit the window.
+
 ## 13.12.2
 
 - Protect against undefined actor/token in the combat tracker (usually due to tokens where the Actor has been deleted).
@@ -31,6 +35,7 @@
     - **Player Cosm** - the cosm of the player will determine which currency is used.
     - **Item Cosm** - the cosm of the item being purchased will determine which currency is used.
     - **Ask Player** - the player will be prompted with the Actor's available currencies, so that they can choose which currency to use.
+  - Hold down SHIFT while dragging to take the Item for free (without popping up the above dialog).
 
 ### Internal Improvements
 

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -3572,6 +3572,10 @@ document-embed .generalHeader {
     margin-bottom: 1em;
     column-gap: 0.5em;
     height: 100%;
+
+    & .full-width {
+      grid-column: 1/3;
+    }
   }
 
   .window-content .raceDescriptionHeadline {

--- a/css/torgeternity.css
+++ b/css/torgeternity.css
@@ -627,6 +627,7 @@ dialog.torgeternity:not(.actor, .item) .window-content,
         gap: 10px;
         margin-bottom: 1em;
         position: relative;
+        padding-left: 0.5em;
 
         &:before {
           content: " ";
@@ -3548,7 +3549,7 @@ document-embed .generalHeader {
     img {
       flex: 0 0 64px;
       height: 64px;
-      margin-right: 6px;
+      margin: 0 1em 0 1em;
       border: none;
     }
 

--- a/module/cards/setUpCardPiles.js
+++ b/module/cards/setUpCardPiles.js
@@ -20,14 +20,7 @@ export async function setUpCardPiles() {
   const deckKeys = [
     'destinyDeck',
     'dramaDeck',
-    'coreEarth',
-    'aysle',
-    'cyberpapacy',
-    'livingLand',
-    'nileEmpire',
-    'orrorsh',
-    'panPacifica',
-    'tharkold',
+    ...Object.keys(CONFIG.torgeternity.cosmDecks)
   ];
 
   console.log(`Torg eternity system // setting up default card decks`);

--- a/module/config.js
+++ b/module/config.js
@@ -14,16 +14,6 @@ torgeternity.cardTypes = {
   cosm: 'torgeternity.cardTypes.cosm',
 };
 
-torgeternity.cosmDecks = {
-  coreEarth: 'torgeternity.cosmDecks.coreEarth',
-  aysle: 'torgeternity.cosmDecks.aysle',
-  cyberpapacy: 'torgeternity.cosmDecks.cyberpapacy',
-  livingLand: 'torgeternity.cosmDecks.livingLand',
-  nileEmpire: 'torgeternity.cosmDecks.nileEmpire',
-  orrorsh: 'torgeternity.cosmDecks.orrorsh',
-  panPacifica: 'torgeternity.cosmDecks.panPacifica',
-  tharkold: 'torgeternity.cosmDecks.tharkold',
-};
 
 torgeternity.dramaConflicts = {
   none: 'torgeternity.drama.none',
@@ -59,18 +49,7 @@ torgeternity.attributeTypes = {
   strength: 'torgeternity.attributes.strength',
 };
 
-torgeternity.cosmTypes = {
-  none: 'torgeternity.cosms.none',
-  coreEarth: 'torgeternity.cosms.coreEarth',
-  livingLand: 'torgeternity.cosms.livingLand',
-  nileEmpire: 'torgeternity.cosms.nileEmpire',
-  aysle: 'torgeternity.cosms.aysle',
-  cyberpapacy: 'torgeternity.cosms.cyberpapacy',
-  tharkold: 'torgeternity.cosms.tharkold',
-  panPacifica: 'torgeternity.cosms.panPacifica',
-  orrorsh: 'torgeternity.cosms.orrorsh',
-  other: 'torgeternity.cosms.other',
-};
+
 
 torgeternity.zones = {
   pure: 'torgeternity.cosms.pure',
@@ -151,10 +130,27 @@ torgeternity.axiomByCosm = {
   },
 };
 
-torgeternity.actionLawCosms = {
-  nileEmpire: 'torgeternity.cosms.nileEmpire',
-  other: 'torgeternity.cosms.other',
-};
+torgeternity.actionLawCosms = ['nileEmpire', 'other'];
+
+torgeternity.cosmPossyIcons = {};
+torgeternity.cosmPossyLargeIcons = {};
+Object.keys(torgeternity.axiomByCosm).forEach(cosm => {
+  torgeternity.cosmPossyIcons[cosm] = `systems/torgeternity/images/possy${(cosm === 'coreEarth') ? 'token' : '_' + cosm}.webp`;
+  torgeternity.cosmPossyLargeIcons[cosm] = (cosm !== 'other') && `systems/torgeternity/images/cosm-icons/${cosm}.webp`;
+});
+
+Hooks.callAll('torgSetupCosms', torgeternity);
+
+torgeternity.cosmDecks = {};
+torgeternity.cosmTypes = { none: 'torgeternity.cosms.none' };
+
+Object.keys(torgeternity.axiomByCosm).forEach(cosm => {
+  torgeternity.cosmDecks[cosm] = `torgeternity.cosmDecks.${cosm}`;
+  torgeternity.cosmTypes[cosm] = `torgeternity.cosms.${cosm}`
+});
+// 'other' always goes last in cosmTypes (since they are in key-addition order in the Possibilities Popup)
+torgeternity.cosmTypes.other ??= 'torgeternity.cosms.other';
+torgeternity.cosmPossyIcons.other ??= `systems/torgeternity/images/possy_other.webp`;
 
 torgeternity.darknessModifiers = {
   none: 'torgeternity.sheetLabels.none',

--- a/module/possibilityByCosm.js
+++ b/module/possibilityByCosm.js
@@ -61,8 +61,8 @@ export class PossibilityByCosm extends foundry.applications.api.HandlebarsApplic
         name: game.i18n.localize(`torgeternity.cosms.${cosm}`),
         uuid: game.i18n.localize(`torgeternity.cosms.${cosm}PossLink`),
         hash: game.i18n.localize(`torgeternity.cosms.${cosm}PossLink2`),
-        icon: `systems/torgeternity/images/possy${(cosm === 'coreEarth') ? 'token' : '_' + cosm}.webp`,
-        largeIcon: (cosm !== 'other') && `systems/torgeternity/images/cosm-icons/${cosm}.webp`,
+        icon: CONFIG.torgeternity.cosmPossyIcons[cosm],
+        largeIcon: CONFIG.torgeternity.cosmPossyLargeIcons[cosm],
         actorField: `${cosm}Poss`
       }
     }

--- a/module/torgeternity.js
+++ b/module/torgeternity.js
@@ -807,7 +807,7 @@ async function rollSkillMacro(skillName, attributeName, isInteractionAttack, DND
 // change the generic threat token to match the cosm's one if it's set in the scene
 Hooks.on('preCreateToken', async (document, data, options, userId) => {
   if (document.texture.src.includes('systems/torgeternity/images/characters/threat')) {
-    const cosm = canvas.scene.getFlag('torgeternity', 'cosm');
+    const cosm = canvas.scene.cosm;
     // not cosmTypes, because that includes 'none'
     if (cosm && Object.hasOwn(CONFIG.torgeternity.cosmDecks, cosm))
       document.updateSource({ 'texture.src': 'systems/torgeternity/images/characters/threat-' + cosm + '.Token.webp' });

--- a/module/torgeternityChatLog.js
+++ b/module/torgeternityChatLog.js
@@ -133,7 +133,7 @@ export default class TorgeternityChatLog extends foundry.applications.sidebar.ta
       canvas.scene.getFlag('torgeternity', 'cosm'),
       canvas.scene.getFlag('torgeternity', 'cosm2'),
     ];
-    const twoPossCosm = Object.keys(CONFIG.torgeternity.actionLawCosms);
+    const twoPossCosm = CONFIG.torgeternity.actionLawCosms;
     if (
       !(
         twoPossCosm.includes(currentCosms[0]) ||

--- a/module/torgeternityChatLog.js
+++ b/module/torgeternityChatLog.js
@@ -129,17 +129,13 @@ export default class TorgeternityChatLog extends foundry.applications.sidebar.ta
 
     // check for Nile/Other/none cosm
     // if no, possibility style to grey
-    const currentCosms = [
-      canvas.scene.getFlag('torgeternity', 'cosm'),
-      canvas.scene.getFlag('torgeternity', 'cosm2'),
-    ];
     const twoPossCosm = CONFIG.torgeternity.actionLawCosms;
     if (
       !(
-        twoPossCosm.includes(currentCosms[0]) ||
-        twoPossCosm.includes(currentCosms[1]) ||
-        currentCosms[0] === 'none' ||
-        currentCosms[0] === undefined
+        twoPossCosm.includes(canvas.scene.torg.cosm) ||
+        twoPossCosm.includes(canvas.scene.torg.cosm2) ||
+        canvas.scene.torg.cosm === 'none' ||
+        canvas.scene.torg.cosm === undefined
       )
     ) {
       test.possibilityStyle = 'disabled';

--- a/templates/items/vehicleAddOn-sheet.hbs
+++ b/templates/items/vehicleAddOn-sheet.hbs
@@ -1,14 +1,12 @@
 <section class="tab stats scrollable {{tab.cssClass}}" data-group="primary" data-tab="stats">
-  <div class="sheet-content" style="display:flex">
-    <div class="item-description">
+  <div class="sheet-content">
+    <div class="main-content full-width">
       <p class="item-data-label">
         {{localize "torgeternity.gear.short-description"}}&nbsp;
-        <input
-          name="system.short-description"
-          type="text"
+        <input name="system.short-description" type="text"
           value="{{item.system.short-description}}" />
       </p>
-      <prose-mirror toggled name="system.description" {{disabled (not @root.editable)}}
+      <prose-mirror toggled name="system.description" class="item-description" {{disabled (not @root.editable)}}
         value="{{ item.system.description }}">{{{ description }}}</prose-mirror>
     </div>
   </div>


### PR DESCRIPTION
- Description field of **Vehicle Add-On Item Sheet** resizes to fit the window.
- #549: **Custom Cosms** are getting closer to being possible:
  - Search for `livingLand` in torgeternity.css, en.json and the *.js files to see what needs customising in your own code.
  - The hook `torgSetupCosms(config)` can be used to modify the available cosms (config contains `CONFIG.torgeternity`)
  - `CONFIG.torgeternity.cosmPossyIcons[cosm]` - full path to icon for scene icons
  - `CONFIG.torgeternity.cosmPossyLargeIcons[cosm]` - full path to icon for Cosm Possibilties dialog
  - You will need to set up the translations and CSS appropriately (e.g. search for livingLand in existing .css and lang/en.json files and copy accordingly)
    - CSS: `#scene-navigation .cosm-card .{cosmname} {background-image: url('path to cosm tent') }`
    - LANG: `torgeternity.cosmDecks.{cosm}`, `torgeternity.cosms.{cosm}`, `torgeternity.cosms.{cosm}PossLink`, `torgeternity.cosms.{cosm}PossLink2`
  - Update game setting `('torgeternity', 'deckSetting')` with your own decks for your own realms (settings.js)
  - Note that when dragging a Threat actor onto the scene, if the the token image path start with `systems/torgeternity/images/characters/threat` then it will get renamed to `threat-{cosm}`