### PR TITLE
fix(enrichers): add chat message and prevent dialog if unskilled is false

### DIFF
--- a/module/enrichers.js
+++ b/module/enrichers.js
@@ -140,6 +140,25 @@ function _onClickInlineCheck(event) {
       skillValue += Math.max(skill.value, attribute.value);
     const isInteractionAttack = (test.attack || interactionAttacks.includes(skillName));
 
+    // check if the skill is unskilled (adds are 0) and the test specifies unkilledUse === 'false' (Maybe parse this boolean?)
+    if (test.unskilledUse === 'false' && skill.adds === 0) {
+      foundry.applications.handlebars.renderTemplate(
+        './systems/torgeternity/templates/chat/skill-error-card.hbs',
+        {
+          message: game.i18n.localize('torgeternity.skills.' + skillName) + ' ' + game.i18n.localize('torgeternity.chatText.check.cantUseUntrained'),
+          actor: actor.uuid,
+          actorPic: actor.img,
+          actorName: actor.name,
+        }).then(content =>
+          ChatMessage.create({
+            speaker: ChatMessage.getSpeaker({ actor }),
+            owner: actor,
+            content: content
+          })
+        )
+      return;
+    }
+
     foundry.utils.mergeObject(test, {
       testType: isInteractionAttack ? 'interactionAttack' : 'skill',
       skillName: skillName,


### PR DESCRIPTION
When using the inline enricher for checks, unskilledUsed is never checked and therefore it always allow actors to perform tests they shouldn't.

Now when using the enricher, if the skills adds are 0 and `unskilledUse` is set to `'false'` (maybe parse this boolean or refer it a number value), display a chatMessage for unskill use
![ezgif-3cb020301c35b6c9](https://github.com/user-attachments/assets/fbe8d4a0-f65e-4c2d-b0bb-abc1a43f04bb)
